### PR TITLE
Rolling window queries

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -48,7 +48,7 @@ ahash = "0.7"
 hashbrown = "0.11"
 arrow = { git = "https://github.com/cube-js/arrow-rs.git", branch = "cube", features = ["prettyprint"] }
 parquet = { git = "https://github.com/cube-js/arrow-rs.git", branch = "cube", features = ["arrow"] }
-sqlparser = { git = "https://github.com/cube-js/sqlparser-rs.git", rev = "a04701767d9d6a9eb99cce9a64dee7e1b7c25b7c" }
+sqlparser = { git = "https://github.com/cube-js/sqlparser-rs.git", rev = "22544370d1f1b608b9a5e75477b1979ed1f7eb72" }
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"

--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -48,7 +48,7 @@ ahash = "0.7"
 hashbrown = "0.11"
 arrow = { git = "https://github.com/cube-js/arrow-rs.git", branch = "cube", features = ["prettyprint"] }
 parquet = { git = "https://github.com/cube-js/arrow-rs.git", branch = "cube", features = ["arrow"] }
-sqlparser = "0.9.0"
+sqlparser = { git = "https://github.com/cube-js/sqlparser-rs.git", rev = "a04701767d9d6a9eb99cce9a64dee7e1b7c25b7c" }
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"

--- a/datafusion/src/cube_ext/datetime.rs
+++ b/datafusion/src/cube_ext/datetime.rs
@@ -1,0 +1,155 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::error::DataFusionError;
+use crate::scalar::ScalarValue;
+use arrow::array::{Array, TimestampNanosecondArray, TimestampNanosecondBuilder};
+use chrono::{DateTime, Datelike, Duration, NaiveDate, TimeZone, Utc};
+
+pub fn date_addsub_array(
+    t: &TimestampNanosecondArray,
+    i: ScalarValue,
+    is_add: bool,
+) -> Result<TimestampNanosecondArray, DataFusionError> {
+    let mut result = TimestampNanosecondBuilder::new(t.len());
+    match i {
+        ScalarValue::IntervalYearMonth(Some(v)) => {
+            for i in 0..t.len() {
+                if t.is_null(i) {
+                    result.append_null()?;
+                } else {
+                    let t = Utc.timestamp_nanos(t.value(i));
+                    result.append_value(
+                        date_addsub_year_month(t, v, is_add)?.timestamp_nanos(),
+                    )?;
+                }
+            }
+        }
+        ScalarValue::IntervalDayTime(Some(v)) => {
+            for i in 0..t.len() {
+                if t.is_null(i) {
+                    result.append_null()?;
+                } else {
+                    let t = Utc.timestamp_nanos(t.value(i));
+                    result.append_value(
+                        date_addsub_day_time(t, v, is_add)?.timestamp_nanos(),
+                    )?;
+                }
+            }
+        }
+        _ => {
+            let name = match is_add {
+                true => "DATE_ADD",
+                false => "DATE_SUB",
+            };
+            return Err(DataFusionError::Plan(format!(
+                "Second argument of `{}` must be a non-null interval",
+                name
+            )));
+        }
+    }
+
+    Ok(result.finish())
+}
+
+pub fn date_addsub_scalar(
+    t: DateTime<Utc>,
+    i: ScalarValue,
+    is_add: bool,
+) -> Result<DateTime<Utc>, DataFusionError> {
+    match i {
+        ScalarValue::IntervalYearMonth(Some(v)) => date_addsub_year_month(t, v, is_add),
+        ScalarValue::IntervalDayTime(Some(v)) => date_addsub_day_time(t, v, is_add),
+        _ => {
+            let name = match is_add {
+                true => "DATE_ADD",
+                false => "DATE_SUB",
+            };
+            return Err(DataFusionError::Plan(format!(
+                "Second argument of `{}` must be a non-null interval",
+                name
+            )));
+        }
+    }
+}
+
+fn date_addsub_year_month(
+    t: DateTime<Utc>,
+    i: i32,
+    is_add: bool,
+) -> Result<DateTime<Utc>, DataFusionError> {
+    let i = match is_add {
+        true => i,
+        false => -i,
+    };
+
+    let mut year = t.year();
+    // Note month is numbered 0..11 in this function.
+    let mut month = t.month() as i32 - 1;
+
+    year += i / 12;
+    month += i % 12;
+
+    if month < 0 {
+        year -= 1;
+        month += 12;
+    }
+    debug_assert!(0 <= month);
+    year += month / 12;
+    month = month % 12;
+
+    match change_ym(t, year, 1 + month as u32) {
+        Some(t) => return Ok(t),
+        None => {
+            return Err(DataFusionError::Execution(format!(
+                "Failed to set date to ({}-{})",
+                year,
+                1 + month
+            )))
+        }
+    };
+}
+
+fn date_addsub_day_time(
+    t: DateTime<Utc>,
+    interval: i64,
+    is_add: bool,
+) -> Result<DateTime<Utc>, DataFusionError> {
+    let i = match is_add {
+        true => interval,
+        false => -interval,
+    };
+
+    let days: i64 = i.signum() * (i.abs() >> 32);
+    let millis: i64 = i.signum() * ((i.abs() << 32) >> 32);
+    return Ok(t + Duration::days(days) + Duration::milliseconds(millis));
+}
+
+fn change_ym(t: DateTime<Utc>, y: i32, m: u32) -> Option<DateTime<Utc>> {
+    debug_assert!(1 <= m && m <= 12);
+    let mut d = t.day();
+    d = d.min(last_day_of_month(y, m));
+    t.with_day(1)?.with_year(y)?.with_month(m)?.with_day(d)
+}
+
+fn last_day_of_month(y: i32, m: u32) -> u32 {
+    debug_assert!(1 <= m && m <= 12);
+    if m == 12 {
+        return 31;
+    }
+    NaiveDate::from_ymd(y, m + 1, 1).pred().day()
+}

--- a/datafusion/src/cube_ext/mod.rs
+++ b/datafusion/src/cube_ext/mod.rs
@@ -16,6 +16,7 @@
 // under the License.
 
 pub mod alias;
+pub mod datetime;
 pub mod join;
 pub mod joinagg;
 pub mod rolling;

--- a/datafusion/src/cube_ext/mod.rs
+++ b/datafusion/src/cube_ext/mod.rs
@@ -18,6 +18,7 @@
 pub mod alias;
 pub mod join;
 pub mod joinagg;
+pub mod rolling;
 pub mod sequence;
 pub mod stream;
 pub mod util;

--- a/datafusion/src/cube_ext/rolling.rs
+++ b/datafusion/src/cube_ext/rolling.rs
@@ -1,0 +1,652 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use crate::cube_ext::stream::StreamWithSchema;
+use crate::cube_ext::util::{cmp_same_types, lexcmp_array_rows};
+use crate::error::DataFusionError;
+use crate::execution::context::ExecutionContextState;
+use crate::logical_plan::window_frames::WindowFrameBound;
+use crate::logical_plan::{
+    Column, DFSchemaRef, Expr, LogicalPlan, UserDefinedLogicalNode,
+};
+use crate::physical_plan::coalesce_batches::concat_batches;
+use crate::physical_plan::expressions::PhysicalSortExpr;
+use crate::physical_plan::hash_aggregate::{append_value, create_builder};
+use crate::physical_plan::planner::ExtensionPlanner;
+use crate::physical_plan::sort::SortExec;
+use crate::physical_plan::{
+    collect, AggregateExpr, ColumnarValue, Distribution, ExecutionPlan, Partitioning,
+    PhysicalPlanner, SendableRecordBatchStream,
+};
+use crate::scalar::ScalarValue;
+use arrow::array::{make_array, BooleanBuilder, MutableArrayData};
+use arrow::compute::filter;
+use arrow::datatypes::{Schema, SchemaRef};
+use arrow::record_batch::RecordBatch;
+use async_trait::async_trait;
+use itertools::Itertools;
+use std::any::Any;
+use std::cmp::{max, Ordering};
+use std::convert::TryInto;
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub struct RollingWindowAggregate {
+    pub schema: DFSchemaRef,
+    pub input: LogicalPlan,
+    pub dimension: Column,
+    pub from: Expr,
+    pub to: Expr,
+    pub every: Expr,
+    pub partition_by: Vec<Column>,
+    pub rolling_aggs: Vec<Expr>,
+}
+
+impl UserDefinedLogicalNode for RollingWindowAggregate {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        let mut e = vec![
+            Expr::Column(self.dimension.clone()),
+            self.from.clone(),
+            self.to.clone(),
+            self.every.clone(),
+        ];
+        e.extend(self.partition_by.iter().map(|c| Expr::Column(c.clone())));
+        e.extend_from_slice(self.rolling_aggs.as_slice());
+        e
+    }
+
+    fn fmt_for_explain(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "ROLLING WINDOW: dimension={}, from={:?}, to={:?}, every={:?}",
+            self.dimension, self.from, self.to, self.every
+        )
+    }
+
+    fn from_template(
+        &self,
+        exprs: &[Expr],
+        inputs: &[LogicalPlan],
+    ) -> Arc<dyn UserDefinedLogicalNode + Send + Sync> {
+        assert_eq!(inputs.len(), 1);
+        assert!(4 + self.partition_by.len() <= exprs.len());
+        let input = inputs[0].clone();
+        let dimension = match &exprs[0] {
+            Expr::Column(c) => c.clone(),
+            o => panic!("Expected column for dimension, got {:?}", o),
+        };
+        let from = exprs[1].clone();
+        let to = exprs[2].clone();
+        let every = exprs[3].clone();
+        let partition_by = exprs[4..4 + self.partition_by.len()]
+            .iter()
+            .map(|c| match c {
+                Expr::Column(c) => c.clone(),
+                o => panic!("Expected column for partition_by, got {:?}", o),
+            })
+            .collect_vec();
+        let rolling_aggs = exprs[4 + self.partition_by.len()..].to_vec();
+        Arc::new(RollingWindowAggregate {
+            schema: self.schema.clone(),
+            input,
+            dimension,
+            from,
+            to,
+            every,
+            partition_by,
+            rolling_aggs,
+        })
+    }
+}
+
+pub struct Planner;
+impl ExtensionPlanner for Planner {
+    fn plan_extension(
+        &self,
+        planner: &dyn PhysicalPlanner,
+        node: &dyn UserDefinedLogicalNode,
+        _logical_inputs: &[&LogicalPlan],
+        physical_inputs: &[Arc<dyn ExecutionPlan>],
+        ctx_state: &ExecutionContextState,
+    ) -> Result<Option<Arc<dyn ExecutionPlan>>, DataFusionError> {
+        use crate::logical_plan;
+        use crate::physical_plan::expressions::Column;
+
+        let node = match node.as_any().downcast_ref::<RollingWindowAggregate>() {
+            None => return Ok(None),
+            Some(n) => n,
+        };
+        assert_eq!(physical_inputs.len(), 1);
+        let input = &physical_inputs[0];
+        let input_dfschema = node.input.schema().as_ref();
+        let input_schema = input.schema();
+
+        let empty_batch = RecordBatch::new_empty(Arc::new(Schema::new(vec![])));
+        let from = planner.create_physical_expr(
+            &node.from,
+            input_dfschema,
+            &input_schema,
+            ctx_state,
+        )?;
+        let from = expect_non_null_scalar("FROM", from.evaluate(&empty_batch)?)?;
+
+        let to = planner.create_physical_expr(
+            &node.to,
+            input_dfschema,
+            &input_schema,
+            ctx_state,
+        )?;
+        let to = expect_non_null_scalar("TO", to.evaluate(&empty_batch)?)?;
+
+        let every = planner.create_physical_expr(
+            &node.every,
+            input_dfschema,
+            &input_schema,
+            ctx_state,
+        )?;
+        let every = expect_non_null_scalar("EVERY", every.evaluate(&empty_batch)?)?;
+
+        if cmp_same_types(&to, &from, true, true) < Ordering::Equal {
+            return Err(DataFusionError::Plan("TO is less than FROM".to_string()));
+        }
+        if cmp_same_types(&add_dim(&from, &every), &from, true, true) <= Ordering::Equal {
+            return Err(DataFusionError::Plan("EVERY must be positive".to_string()));
+        }
+
+        let rolling_aggs = node
+            .rolling_aggs
+            .iter()
+            .map(|e| -> Result<_, DataFusionError> {
+                match e {
+                    Expr::RollingAggregate { agg, start, end } => {
+                        let start = match start {
+                            WindowFrameBound::Preceding(v) => {
+                                ScalarValue::Int64(convert_bound(*v)?)
+                            }
+                            WindowFrameBound::CurrentRow => ScalarValue::Int64(Some(0)),
+                            WindowFrameBound::Following(_) => {
+                                panic!("unexpected FOLLOWING bound")
+                            }
+                        };
+                        let end = match end {
+                            WindowFrameBound::Following(v) => {
+                                ScalarValue::Int64(convert_bound(*v)?)
+                            }
+                            WindowFrameBound::CurrentRow => ScalarValue::Int64(Some(0)),
+                            WindowFrameBound::Preceding(_) => {
+                                panic!("unexpected PRECEDING bound")
+                            }
+                        };
+                        let agg = planner.create_aggregate_expr(
+                            agg,
+                            input_dfschema,
+                            &input_schema,
+                            ctx_state,
+                        )?;
+                        Ok(RollingAgg {
+                            agg,
+                            preceding: Some(start),
+                            following: Some(end),
+                        })
+                    }
+                    _ => panic!("expected ROLLING() aggregate, got {:?}", e),
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let phys_col = |c: &logical_plan::Column| -> Result<_, DataFusionError> {
+            Ok(Column::new(&c.name, input_dfschema.index_of_column(c)?))
+        };
+        let dimension = phys_col(&node.dimension)?;
+        // TODO: filter inputs by date.
+        // Do preliminary sorting.
+        let mut sort_key = Vec::with_capacity(input_schema.fields().len());
+        let mut group_key = Vec::with_capacity(input_schema.fields().len() - 1);
+        for c in &node.partition_by {
+            let c = phys_col(c)?;
+            sort_key.push(PhysicalSortExpr {
+                expr: Arc::new(c.clone()),
+                options: Default::default(),
+            });
+            group_key.push(c);
+        }
+        sort_key.push(PhysicalSortExpr {
+            expr: Arc::new(dimension.clone()),
+            options: Default::default(),
+        });
+
+        let sort = Arc::new(SortExec::try_new(sort_key, input.clone())?);
+        let schema = node.schema.to_schema_ref();
+
+        Ok(Some(Arc::new(RollingWindowAggExec {
+            schema,
+            sorted_input: sort,
+            group_key,
+            rolling_aggs,
+            dimension,
+            from,
+            to,
+            every,
+        })))
+    }
+}
+
+fn convert_bound(v: Option<u64>) -> Result<Option<i64>, DataFusionError> {
+    let v = match v {
+        None => return Ok(None),
+        Some(v) => v,
+    };
+    let s = match v.try_into() {
+        Err(_) => {
+            return Err(DataFusionError::Plan(format!(
+            "rolling window frame bound {} is too large, must be convertible to Int64",
+            v
+        )))
+        }
+        Ok(s) => s,
+    };
+    Ok(Some(s))
+}
+
+#[derive(Debug, Clone)]
+pub struct RollingAgg {
+    pub preceding: Option<ScalarValue>,
+    pub following: Option<ScalarValue>,
+    pub agg: Arc<dyn AggregateExpr>,
+}
+
+#[derive(Debug)]
+pub struct RollingWindowAggExec {
+    pub schema: SchemaRef,
+    pub sorted_input: Arc<dyn ExecutionPlan>,
+    pub group_key: Vec<crate::physical_plan::expressions::Column>,
+    pub rolling_aggs: Vec<RollingAgg>,
+    pub dimension: crate::physical_plan::expressions::Column,
+    pub from: ScalarValue,
+    pub to: ScalarValue,
+    pub every: ScalarValue,
+}
+
+#[async_trait]
+impl ExecutionPlan for RollingWindowAggExec {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn output_partitioning(&self) -> Partitioning {
+        Partitioning::UnknownPartitioning(1)
+    }
+
+    fn required_child_distribution(&self) -> Distribution {
+        Distribution::UnspecifiedDistribution
+    }
+
+    fn children(&self) -> Vec<Arc<dyn ExecutionPlan>> {
+        vec![self.sorted_input.clone()]
+    }
+
+    fn with_new_children(
+        &self,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+        assert_eq!(children.len(), 1);
+        Ok(Arc::new(RollingWindowAggExec {
+            schema: self.schema(),
+            sorted_input: children.remove(0),
+            group_key: self.group_key.clone(),
+            rolling_aggs: self.rolling_aggs.clone(),
+            dimension: self.dimension.clone(),
+            from: self.from.clone(),
+            to: self.to.clone(),
+            every: self.every.clone(),
+        }))
+    }
+
+    async fn execute(
+        &self,
+        partition: usize,
+    ) -> Result<SendableRecordBatchStream, DataFusionError> {
+        assert_eq!(partition, 0);
+        // Sort keeps everything in-memory anyway. So don't stream and keep implementation simple.
+        let batches = collect(self.sorted_input.clone()).await?;
+        let num_rows = batches.iter().map(|b| b.num_rows()).sum();
+        let input = concat_batches(&self.sorted_input.schema(), &batches, num_rows)?;
+
+        let num_rows = input.num_rows();
+        let key_cols = self
+            .group_key
+            .iter()
+            .map(|c| input.columns()[c.index()].clone())
+            .collect_vec();
+        let other_cols = input
+            .columns()
+            .iter()
+            .enumerate()
+            .filter_map(|(i, c)| {
+                if self.dimension.index() == i
+                    || self.group_key.iter().any(|c| c.index() == i)
+                {
+                    None
+                } else {
+                    Some(c.clone())
+                }
+            })
+            .collect_vec();
+        let agg_inputs = self
+            .rolling_aggs
+            .iter()
+            .map(|r| {
+                r.agg
+                    .expressions()
+                    .iter()
+                    .map(|e| -> Result<_, DataFusionError> {
+                        Ok(e.evaluate(&input)?.into_array(num_rows))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let mut accumulators = self
+            .rolling_aggs
+            .iter()
+            .map(|r| r.agg.create_accumulator())
+            .collect::<Result<Vec<_>, _>>()?;
+        let dimension = input.column(self.dimension.index());
+
+        let mut out_dim = create_builder(&self.from);
+        let mut out_keys = key_cols
+            .iter()
+            .map(|c| MutableArrayData::new(vec![c.data()], true, 0))
+            .collect_vec();
+        let mut out_aggs = Vec::with_capacity(self.rolling_aggs.len());
+        // This filter must be applied prior to returning the values.
+        let mut out_aggs_keep = BooleanBuilder::new(0);
+        let mut out_other = other_cols
+            .iter()
+            .map(|c| MutableArrayData::new(vec![c.data()], true, 0))
+            .collect_vec();
+        let mut row_i = 0;
+        let mut any_group_had_values = vec![];
+        while row_i < num_rows {
+            let group_start = row_i;
+            while row_i + 1 < num_rows
+                && lexcmp_array_rows(key_cols.iter(), row_i, row_i + 1).is_eq()
+            {
+                row_i += 1;
+            }
+            let group_end = row_i + 1;
+            row_i = group_end;
+
+            // Compute aggregate on each interesting date and add them to the output.
+            let mut had_values = Vec::new();
+            for (ri, r) in self.rolling_aggs.iter().enumerate() {
+                // Avoid running indefinitely due to all kinds of errors.
+                let mut window_start = group_start;
+                let mut window_end = group_start;
+
+                let mut d = self.from.clone();
+                let mut d_iter = 0;
+                while cmp_same_types(&d, &self.to, true, true) <= Ordering::Equal {
+                    while window_start < group_end
+                        && !meets_preceding(
+                            &ScalarValue::try_from_array(dimension, window_start)
+                                .unwrap(),
+                            &d,
+                            r.preceding.as_ref(),
+                        )
+                    {
+                        window_start += 1;
+                    }
+                    window_end = max(window_end, window_start);
+                    while window_end < group_end
+                        && meets_following(
+                            &ScalarValue::try_from_array(dimension, window_end).unwrap(),
+                            &d,
+                            r.following.as_ref(),
+                        )
+                    {
+                        window_end += 1;
+                    }
+                    if had_values.len() == d_iter {
+                        had_values.push(window_start != window_end);
+                    } else {
+                        had_values[d_iter] |= window_start != window_end;
+                    }
+
+                    // TODO: pick easy performance wins for SUM() and AVG() with subtraction.
+                    //       Also experiment with interval trees for other accumulators.
+                    accumulators[ri].reset();
+                    accumulators[ri].update_batch(
+                        &agg_inputs[ri]
+                            .iter()
+                            .map(|a| a.slice(window_start, window_end - window_start))
+                            .collect_vec(),
+                    )?;
+                    let v = accumulators[ri].evaluate()?;
+                    if ri == out_aggs.len() {
+                        out_aggs.push(create_builder(&v));
+                    }
+                    append_value(out_aggs[ri].as_mut(), &v)?;
+
+                    const MAX_DIM_ITERATIONS: usize = 10_000_000;
+                    d_iter += 1;
+                    if d_iter == MAX_DIM_ITERATIONS {
+                        return Err(DataFusionError::Execution(
+                            "reached the limit of iterations for rolling window dimensions"
+                                .to_string(),
+                        ));
+                    }
+                    d = add_dim(&d, &self.every);
+                }
+            }
+
+            if any_group_had_values.is_empty() {
+                any_group_had_values = had_values.clone();
+            } else {
+                for i in 0..had_values.len() {
+                    any_group_had_values[i] |= had_values[i];
+                }
+            }
+
+            // Add keys, dimension and non-aggregate columns to the output.
+            let mut d = self.from.clone();
+            let mut d_iter = 0;
+            let mut matching_row_lower_bound = 0;
+            while cmp_same_types(&d, &self.to, true, true) <= Ordering::Equal {
+                if !had_values[d_iter] {
+                    out_aggs_keep.append_value(false)?;
+
+                    d_iter += 1;
+                    d = add_dim(&d, &self.every);
+                    continue;
+                } else {
+                    out_aggs_keep.append_value(true)?;
+                }
+                append_value(out_dim.as_mut(), &d)?;
+                for i in 0..key_cols.len() {
+                    out_keys[i].extend(0, group_start, group_start + 1)
+                }
+                // Find the matching row to add other columns.
+                while matching_row_lower_bound < group_end
+                    && cmp_same_types(
+                        &ScalarValue::try_from_array(dimension, matching_row_lower_bound)
+                            .unwrap(),
+                        &d,
+                        true,
+                        true,
+                    ) < Ordering::Equal
+                {
+                    matching_row_lower_bound += 1;
+                }
+                if matching_row_lower_bound < group_end
+                    && ScalarValue::try_from_array(dimension, matching_row_lower_bound)
+                        .unwrap()
+                        == d
+                {
+                    for i in 0..other_cols.len() {
+                        out_other[i].extend(
+                            0,
+                            matching_row_lower_bound,
+                            matching_row_lower_bound + 1,
+                        );
+                    }
+                } else {
+                    for o in &mut out_other {
+                        o.extend_nulls(1);
+                    }
+                }
+                d_iter += 1;
+                d = add_dim(&d, &self.every);
+            }
+        }
+
+        // We also promise to produce null values for dates missing in the input.
+        let mut d = self.from.clone();
+        let mut num_empty_dims = 0;
+        for i in 0..any_group_had_values.len() {
+            if !any_group_had_values[i] {
+                append_value(out_dim.as_mut(), &d)?;
+                num_empty_dims += 1;
+            }
+            d = add_dim(&d, &self.every);
+        }
+        for c in &mut out_keys {
+            c.extend_nulls(num_empty_dims);
+        }
+        for c in &mut out_other {
+            c.extend_nulls(num_empty_dims);
+        }
+        for i in 0..out_aggs.len() {
+            accumulators[i].reset();
+            let null = accumulators[i].evaluate()?;
+            for _ in 0..num_empty_dims {
+                append_value(out_aggs[i].as_mut(), &null)?;
+            }
+        }
+        for _ in 0..num_empty_dims {
+            out_aggs_keep.append_value(true)?;
+        }
+
+        // Produce final output.
+        if out_dim.is_empty() {
+            return Ok(Box::pin(StreamWithSchema::wrap(
+                self.schema(),
+                futures::stream::empty(),
+            )));
+        };
+
+        let mut r =
+            Vec::with_capacity(1 + out_keys.len() + out_other.len() + out_aggs.len());
+        r.push(out_dim.finish());
+        for k in out_keys {
+            r.push(make_array(k.freeze()));
+        }
+        for o in out_other {
+            r.push(make_array(o.freeze()));
+        }
+        let out_aggs_keep = out_aggs_keep.finish();
+        for mut a in out_aggs {
+            r.push(filter(a.finish().as_ref(), &out_aggs_keep)?);
+        }
+        let r = RecordBatch::try_new(self.schema(), r)?;
+        Ok(Box::pin(StreamWithSchema::wrap(
+            self.schema(),
+            futures::stream::iter(vec![Ok(r)]),
+        )))
+    }
+}
+
+fn add_dim(l: &ScalarValue, r: &ScalarValue) -> ScalarValue {
+    match (l, r) {
+        (ScalarValue::Int64(Some(l)), ScalarValue::Int64(Some(r))) => {
+            ScalarValue::Int64(Some(l + r))
+        }
+        _ => panic!("unsupported dimension type"),
+    }
+}
+
+fn meets_preceding(
+    value: &ScalarValue,
+    current: &ScalarValue,
+    prec: Option<&ScalarValue>,
+) -> bool {
+    let prec = match prec {
+        Some(p) => p,
+        None => return true,
+    };
+    if prec.is_null() {
+        return true;
+    }
+    if current.is_null() {
+        return value.is_null();
+    }
+    if value.is_null() {
+        return false;
+    }
+    match (current, value, prec) {
+        (
+            ScalarValue::Int64(Some(current)),
+            ScalarValue::Int64(Some(value)),
+            ScalarValue::Int64(Some(prec)),
+        ) => return current - value <= *prec,
+        _ => panic!(
+            "unsupported values in rolling window: ({}, {}, {})",
+            current, value, prec
+        ),
+    }
+}
+
+fn meets_following(
+    value: &ScalarValue,
+    current: &ScalarValue,
+    prec: Option<&ScalarValue>,
+) -> bool {
+    meets_preceding(current, value, prec)
+}
+
+fn expect_non_null_scalar(
+    var: &str,
+    v: ColumnarValue,
+) -> Result<ScalarValue, DataFusionError> {
+    match v {
+        ColumnarValue::Array(_) => {
+            return Err(DataFusionError::Plan(format!(
+                "expected scalar for {}, got array",
+                var
+            )))
+        }
+        ColumnarValue::Scalar(s) if s.is_null() => {
+            return Err(DataFusionError::Plan(format!("{} must not be null", var)))
+        }
+        ColumnarValue::Scalar(s) => return Ok(s),
+    }
+}

--- a/datafusion/src/cube_ext/util.rs
+++ b/datafusion/src/cube_ext/util.rs
@@ -356,3 +356,17 @@ pub fn cmp_array_row_same_types(
 
     cube_match_array!(l, cmp_row);
 }
+
+pub fn lexcmp_array_rows<'a>(
+    cols: impl Iterator<Item = &'a ArrayRef>,
+    l_row: usize,
+    r_row: usize,
+) -> Ordering {
+    for c in cols {
+        let o = cmp_array_row_same_types(c, l_row, c, r_row);
+        if o != Ordering::Equal {
+            return o;
+        }
+    }
+    Ordering::Equal
+}

--- a/datafusion/src/optimizer/utils.rs
+++ b/datafusion/src/optimizer/utils.rs
@@ -348,7 +348,7 @@ pub fn rewrite_expression(expr: &Expr, expressions: &[Expr]) -> Result<Expr> {
                     args: expressions[..partition_index].to_vec(),
                     partition_by: expressions[partition_index + 1..sort_index].to_vec(),
                     order_by: expressions[sort_index + 1..].to_vec(),
-                    window_frame: *window_frame,
+                    window_frame: window_frame.clone(),
                 })
             }
         }

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -1203,7 +1203,7 @@ pub fn create_accumulators(
 }
 
 #[allow(unused_variables)]
-fn create_builder(s: &ScalarValue) -> Box<dyn ArrayBuilder> {
+pub(crate) fn create_builder(s: &ScalarValue) -> Box<dyn ArrayBuilder> {
     macro_rules! create_list_builder {
         ($v: expr, $inner_data_type: expr, ListBuilder $(, $rest: tt)*) => {{
             panic!("nested lists not supported")
@@ -1226,7 +1226,7 @@ fn create_builder(s: &ScalarValue) -> Box<dyn ArrayBuilder> {
 }
 
 #[allow(unused_variables)]
-fn append_value(b: &mut dyn ArrayBuilder, v: &ScalarValue) -> Result<()> {
+pub(crate) fn append_value(b: &mut dyn ArrayBuilder, v: &ScalarValue) -> Result<()> {
     let b = b.as_any_mut();
     macro_rules! append_list_value {
         ($list: expr, $dummy: expr, $inner_data_type: expr, ListBuilder $(, $rest: tt)*) => {{

--- a/datafusion/src/physical_plan/merge_sort.rs
+++ b/datafusion/src/physical_plan/merge_sort.rs
@@ -36,7 +36,7 @@ use super::{RecordBatchStream, SendableRecordBatchStream};
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::{ExecutionPlan, OptimizerHints, Partitioning};
 
-use crate::cube_ext::util::cmp_array_row_same_types;
+use crate::cube_ext::util::{cmp_array_row_same_types, lexcmp_array_rows};
 use crate::physical_plan::expressions::Column;
 use crate::physical_plan::memory::MemoryStream;
 use arrow::array::{make_array, MutableArrayData};
@@ -543,20 +543,6 @@ fn merge_sort(
         pos,
         RecordBatch::try_new(batches[0].1.schema(), result_cols)?,
     ))
-}
-
-fn lexcmp_array_rows<'a>(
-    cols: impl Iterator<Item = &'a ArrayRef>,
-    l_row: usize,
-    r_row: usize,
-) -> Ordering {
-    for c in cols {
-        let o = cmp_array_row_same_types(c, l_row, c, r_row);
-        if o != Ordering::Equal {
-            return o;
-        }
-    }
-    Ordering::Equal
 }
 
 impl RecordBatchStream for MergeSortStream {

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -1396,7 +1396,7 @@ impl DefaultPhysicalPlanner {
                     &args,
                     &partition_by,
                     &order_by,
-                    *window_frame,
+                    window_frame.clone(),
                     physical_input_schema,
                 )
             }

--- a/datafusion/src/physical_plan/planner.rs
+++ b/datafusion/src/physical_plan/planner.rs
@@ -257,6 +257,7 @@ impl Default for DefaultPhysicalPlanner {
                 Arc::new(LogicalAliasPlanner {}),
                 Arc::new(CrossJoinPlanner {}),
                 Arc::new(CrossJoinAggPlanner {}),
+                Arc::new(crate::cube_ext::rolling::Planner {}),
             ],
         }
     }
@@ -330,6 +331,7 @@ impl DefaultPhysicalPlanner {
         extension_planners.insert(0, Arc::new(LogicalAliasPlanner {}));
         extension_planners.insert(1, Arc::new(CrossJoinPlanner {}));
         extension_planners.insert(2, Arc::new(CrossJoinAggPlanner {}));
+        extension_planners.insert(3, Arc::new(crate::cube_ext::rolling::Planner {}));
         Self { extension_planners }
     }
 

--- a/datafusion/src/physical_plan/windows/aggregate.rs
+++ b/datafusion/src/physical_plan/windows/aggregate.rs
@@ -59,7 +59,10 @@ impl AggregateWindowExpr {
     /// the aggregate window function operates based on window frame, and by default the mode is
     /// "range".
     fn evaluation_mode(&self) -> WindowFrameUnits {
-        self.window_frame.unwrap_or_default().units
+        self.window_frame
+            .as_ref()
+            .map(|f| f.units)
+            .unwrap_or(WindowFrameUnits::Range)
     }
 
     /// create a new accumulator based on the underlying aggregation function

--- a/datafusion/src/sql/planner.rs
+++ b/datafusion/src/sql/planner.rs
@@ -1121,7 +1121,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 leading_precision,
                 last_field,
                 fractional_seconds_precision,
-            }) => self.sql_interval_to_literal(
+            }) => Self::sql_interval_to_literal(
                 value,
                 leading_field,
                 leading_precision,
@@ -1475,13 +1475,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     }
                 };
 
-                let start = first_bound.clone().into();
+                let start = first_bound.clone().try_into()?;
                 let end = second_bound
                     .clone()
                     .unwrap_or(sqlparser::ast::WindowFrameBound::CurrentRow)
-                    .into();
+                    .try_into()?;
 
-                check_window_bound_order(start, end)?;
+                check_window_bound_order(&start, &end)?;
 
                 Ok(Expr::RollingAggregate {
                     agg: Box::new(agg),
@@ -1532,8 +1532,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         }
     }
 
-    fn sql_interval_to_literal(
-        &self,
+    #[allow(missing_docs)]
+    pub(crate) fn sql_interval_to_literal(
         value: &str,
         leading_field: &Option<DateTimeField>,
         leading_precision: &Option<u64>,

--- a/datafusion/src/sql/utils.rs
+++ b/datafusion/src/sql/utils.rs
@@ -261,7 +261,7 @@ where
                     .iter()
                     .map(|e| clone_with_replacement(e, replacement_fn))
                     .collect::<Result<Vec<_>>>()?,
-                window_frame: *window_frame,
+                window_frame: window_frame.clone(),
             }),
             Expr::AggregateUDF { fun, args } => Ok(Expr::AggregateUDF {
                 fun: fun.clone(),


### PR DESCRIPTION
CubeStore extension to implement rolling window measures in CubeJS.
Tests are in the CubeStore repository.

The syntax is of the form:
```
SELECT dim, key1, key2, other,
       ROLLING(SUM(x) RANGE BETWEEN 7 PRECEDING AND UNBOUNDED FOLLOWING)
       ROLLING(AVG(x) RANGE BETWEEN 7 PRECEDING AND UNBOUNDED FOLLOWING)
FROM input
ROLLING_WINDOW
  DIMENSION dim
  PARTITION BY key1, key2
  FROM 0 to 10 EVERY 2
```

Semantics are roughly:
  - compute rolling window aggregations over input data,
  - window "rolls over" the `DIMENSION` column, only values defined in
    the range by `FROM .. TO .. EVERY ..` are reported,
  - each "group" defined by columns in `PARTITION BY` is handled
    and reported independently,

Current limitations:
  - only ranges with up to 10M points are supported to avoid infinite
    loops are accidental DOS. This is still a fairly large limit and
    can lead to DOS given enough input data.