### PR TITLE
Support aggregation in rolling window queries

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -48,7 +48,7 @@ ahash = "0.7"
 hashbrown = "0.11"
 arrow = { git = "https://github.com/cube-js/arrow-rs.git", branch = "cube", features = ["prettyprint"] }
 parquet = { git = "https://github.com/cube-js/arrow-rs.git", branch = "cube", features = ["arrow"] }
-sqlparser = { git = "https://github.com/cube-js/sqlparser-rs.git", rev = "6008dfab082a3455c54b023be878d92ec9acef43" }
+sqlparser = { git = "https://github.com/cube-js/sqlparser-rs.git", rev = "2fcd06f7354e8c85f170b49a08fc018749289a40" }
 paste = "^1.0"
 num_cpus = "1.13.0"
 chrono = "0.4"


### PR DESCRIPTION
The idea is to aggregate inside each matching partition and dimension.
`ROLLING_WINDOW` clause now has an optional `GROUP BY DIMENSION <expr>`
argument. Corresponding expression is used both as a grouping key for
non-rolling aggregates and a "join" key to match to the rolling window
output.