### PR TITLE
Use total order to compare floats in grouping

### DIFF
--- a/datafusion/src/cube_ext/mod.rs
+++ b/datafusion/src/cube_ext/mod.rs
@@ -19,6 +19,7 @@ pub mod alias;
 pub mod datetime;
 pub mod join;
 pub mod joinagg;
+pub mod ordfloat;
 pub mod rolling;
 pub mod sequence;
 pub mod stream;

--- a/datafusion/src/cube_ext/ordfloat.rs
+++ b/datafusion/src/cube_ext/ordfloat.rs
@@ -1,0 +1,105 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+use arrow::compute::{total_cmp_32, total_cmp_64};
+use serde::{Deserialize, Serialize};
+use smallvec::alloc::fmt::Formatter;
+use std::cmp::Ordering;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct OrdF64(pub f64);
+
+impl PartialEq for OrdF64 {
+    fn eq(&self, other: &Self) -> bool {
+        return self.cmp(other) == Ordering::Equal;
+    }
+}
+impl Eq for OrdF64 {}
+
+impl PartialOrd for OrdF64 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        return Some(self.cmp(other));
+    }
+}
+
+impl Ord for OrdF64 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        return total_cmp_64(self.0, other.0);
+    }
+}
+
+impl fmt::Display for OrdF64 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        self.0.fmt(f)
+    }
+}
+
+impl From<f64> for OrdF64 {
+    fn from(v: f64) -> Self {
+        return Self(v);
+    }
+}
+
+impl Hash for OrdF64 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        format!("{}", self.0).hash(state);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct OrdF32(pub f32);
+
+impl PartialEq for OrdF32 {
+    fn eq(&self, other: &Self) -> bool {
+        return self.cmp(other) == Ordering::Equal;
+    }
+}
+impl Eq for OrdF32 {}
+
+impl PartialOrd for OrdF32 {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        return Some(self.cmp(other));
+    }
+}
+
+impl Ord for OrdF32 {
+    fn cmp(&self, other: &Self) -> Ordering {
+        return total_cmp_32(self.0, other.0);
+    }
+}
+
+impl fmt::Display for OrdF32 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        self.0.fmt(f)
+    }
+}
+
+impl From<f32> for OrdF32 {
+    fn from(v: f32) -> Self {
+        return Self(v);
+    }
+}
+
+impl Hash for OrdF32 {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        format!("{}", self.0).hash(state);
+    }
+}

--- a/datafusion/src/physical_plan/group_scalar.rs
+++ b/datafusion/src/physical_plan/group_scalar.rs
@@ -17,9 +17,9 @@
 
 //! Defines scalars used to construct groups, ex. in GROUP BY clauses.
 
-use ordered_float::OrderedFloat;
 use std::convert::{From, TryFrom};
 
+use crate::cube_ext::ordfloat::{OrdF32, OrdF64};
 use crate::error::{DataFusionError, Result};
 use crate::scalar::ScalarValue;
 use arrow::datatypes::DataType;
@@ -29,8 +29,8 @@ use arrow::datatypes::DataType;
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum GroupByScalar {
     Null,
-    Float32(OrderedFloat<f32>),
-    Float64(OrderedFloat<f64>),
+    Float32(OrdF32),
+    Float64(OrdF64),
     UInt8(u8),
     UInt16(u16),
     UInt32(u32),
@@ -55,12 +55,8 @@ impl TryFrom<&ScalarValue> for GroupByScalar {
 
     fn try_from(scalar_value: &ScalarValue) -> Result<Self> {
         Ok(match scalar_value {
-            ScalarValue::Float32(Some(v)) => {
-                GroupByScalar::Float32(OrderedFloat::from(*v))
-            }
-            ScalarValue::Float64(Some(v)) => {
-                GroupByScalar::Float64(OrderedFloat::from(*v))
-            }
+            ScalarValue::Float32(Some(v)) => GroupByScalar::Float32(OrdF32::from(*v)),
+            ScalarValue::Float64(Some(v)) => GroupByScalar::Float64(OrdF64::from(*v)),
             ScalarValue::Boolean(Some(v)) => GroupByScalar::Boolean(*v),
             ScalarValue::Int8(Some(v)) => GroupByScalar::Int8(*v),
             ScalarValue::Int16(Some(v)) => GroupByScalar::Int16(*v),
@@ -118,8 +114,8 @@ impl GroupByScalar {
             GroupByScalar::Null => {
                 ScalarValue::try_from(ty).expect("could not create null")
             }
-            GroupByScalar::Float32(v) => ScalarValue::Float32(Some((*v).into())),
-            GroupByScalar::Float64(v) => ScalarValue::Float64(Some((*v).into())),
+            GroupByScalar::Float32(v) => ScalarValue::Float32(Some((*v).0)),
+            GroupByScalar::Float64(v) => ScalarValue::Float64(Some((*v).0)),
             GroupByScalar::Boolean(v) => ScalarValue::Boolean(Some(*v)),
             GroupByScalar::Int8(v) => ScalarValue::Int8(Some(*v)),
             GroupByScalar::Int16(v) => ScalarValue::Int16(Some(*v)),

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -61,7 +61,6 @@ use arrow::{
     record_batch::RecordBatch,
 };
 use hashbrown::HashMap;
-use ordered_float::OrderedFloat;
 use pin_project_lite::pin_project;
 
 use arrow::array::{
@@ -77,6 +76,7 @@ use super::{
 
 use crate::cube_ext;
 
+use crate::cube_ext::ordfloat::{OrdF32, OrdF64};
 use crate::physical_plan::sorted_aggregate::SortedAggState;
 use compute::cast;
 use smallvec::smallvec;
@@ -1395,11 +1395,11 @@ pub(crate) fn create_group_by_value(col: &ArrayRef, row: usize) -> Result<GroupB
     match col.data_type() {
         DataType::Float32 => {
             let array = col.as_any().downcast_ref::<Float32Array>().unwrap();
-            Ok(GroupByScalar::Float32(OrderedFloat::from(array.value(row))))
+            Ok(GroupByScalar::Float32(OrdF32::from(array.value(row))))
         }
         DataType::Float64 => {
             let array = col.as_any().downcast_ref::<Float64Array>().unwrap();
-            Ok(GroupByScalar::Float64(OrderedFloat::from(array.value(row))))
+            Ok(GroupByScalar::Float64(OrdF64::from(array.value(row))))
         }
         DataType::UInt8 => {
             let array = col.as_any().downcast_ref::<UInt8Array>().unwrap();

--- a/datafusion/src/physical_plan/merge_sort.rs
+++ b/datafusion/src/physical_plan/merge_sort.rs
@@ -489,6 +489,7 @@ fn merge_sort(
                     sort_keys[c.index]
                         .iter()
                         .map(|a| a.slice(pos[c.index] + len - 1, 2))
+                        .collect::<Vec<_>>(),
                 );
                 let k = Key {
                     values: &sort_keys[c.index],
@@ -537,7 +538,10 @@ fn merge_sort(
                     <= Ordering::Equal,
                 "unsorted data after merge. row {}. data: {:?}",
                 i - 1,
-                key_cols.iter().map(|a| a.slice(i - 1, 2))
+                key_cols
+                    .iter()
+                    .map(|a| a.slice(i - 1, 2))
+                    .collect::<Vec<_>>(),
             );
         }
     }


### PR DESCRIPTION
Current implementation incorrectly equates negative zero and zero.
This can produce invalid results on merge and compactions in CubeStore.