### PR TITLE
fix: Ignore equal expression names in projection

### DIFF
--- a/datafusion/src/logical_plan/builder.rs
+++ b/datafusion/src/logical_plan/builder.rs
@@ -810,7 +810,6 @@ pub fn project_with_alias(
                 .push(columnize_expr(normalize_col(e, &plan)?, input_schema)),
         }
     }
-    validate_unique_names("Projections", projected_expr.iter(), input_schema)?;
     let input_schema = DFSchema::new(exprlist_to_fields(&projected_expr, input_schema)?)?;
     let schema = match alias {
         Some(ref alias) => input_schema.replace_qualifier(alias.as_str()),


### PR DESCRIPTION
This PR allows non-unique expression names.
There are some edge cases to consider but otherwise the resulting behavior is mostly similar to MySQL and PostgreSQL.

No expectedly failing tests were edited, removed, or ignored in this PR due to inability to run tests.