### PR TITLE
chore: remove async thread spawning in library code

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -58,6 +58,7 @@ futures = "0.3"
 pin-project-lite= "^0.2.0"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
+async-stream = "0.3.2"
 log = "^0.4"
 md-5 = { version = "^0.9.1", optional = true }
 sha2 = { version = "^0.9.1", optional = true }

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -1068,28 +1068,6 @@ impl Stream for HashAggregateStream {
     ) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
         return Pin::new(&mut this.stream).poll_next(cx);
-
-        // if self.finished {
-        //     return Poll::Ready(None);
-        // }
-        //
-        // // is the output ready?
-        // let output_poll = this.output.poll(cx);
-        //
-        // match output_poll {
-        //     Poll::Ready(result) => {
-        //         *this.finished = true;
-        //
-        //         // check for error in receiving channel and unwrap actual result
-        //         let result = match result {
-        //             Err(e) => Err(ArrowError::ExternalError(Box::new(e))), // error receiving
-        //             Ok(result) => result,
-        //         };
-        //
-        //         Poll::Ready(Some(result))
-        //     }
-        //     Poll::Pending => Poll::Pending,
-        // }
     }
 }
 


### PR DESCRIPTION
# Which issue does this PR close?

N/A

 # Rationale for this change

No async thread spawning in library code. Consistent stack traces. Concrete benefit: panic unwinding in app code.

# What changes are included in this PR?

See above.

# Are there any user-facing changes?

No.