### PR TITLE
fix: Normalize column names for joins and aliased columns

### DIFF
--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -34,7 +34,7 @@ simd = ["datafusion/simd"]
 [dependencies]
 ahash = { version = "0.7", default-features = false }
 
-arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2" }
+arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573" }
 async-trait = "0.1.41"
 chrono = { version = "0.4", default-features = false }
 clap = { version = "3", features = ["derive", "cargo"] }

--- a/ballista/rust/executor/Cargo.toml
+++ b/ballista/rust/executor/Cargo.toml
@@ -33,8 +33,8 @@ snmalloc = ["snmalloc-rs"]
 
 [dependencies]
 anyhow = "1"
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2" }
-arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573" }
+arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573" }
 async-trait = "0.1.41"
 ballista-core = { path = "../core", version = "0.6.0" }
 chrono = { version = "0.4", default-features = false }

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 rust-version = "1.59"
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573" }
 ballista = { path = "../ballista/rust/client", version = "0.6.0", optional = true }
 clap = { version = "3", features = ["derive", "cargo"] }
 datafusion = { path = "../datafusion/core", version = "7.0.0" }

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2" }
+arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573" }
 async-trait = "0.1.41"
 datafusion = { path = "../datafusion/core" }
 futures = "0.3"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -38,10 +38,10 @@ jit = ["cranelift-module"]
 pyarrow = ["pyo3"]
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["prettyprint"] }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.82.0", optional = true }
 ordered-float = "2.10"
-parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["arrow"], optional = true }
+parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "47a7b66c64417662c6c30f0decdb0a900fc97a56" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -55,7 +55,7 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["prettyprint"] }
 async-trait = "0.1.41"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 chrono = { version = "0.4", default-features = false }
@@ -72,7 +72,7 @@ num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
 ordered-float = "2.10"
 parking_lot = "0.12"
-parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["arrow"] }
+parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["arrow"] }
 paste = "^1.0"
 pin-project-lite= "^0.2.7"
 pyo3 = { version = "0.16", optional = true }

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["prettyprint"] }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/src/optimizer/projection_push_down.rs
+++ b/datafusion/core/src/optimizer/projection_push_down.rs
@@ -206,8 +206,16 @@ fn optimize_plan(
             ..
         }) => {
             for (l, r) in on {
-                new_required_columns.insert(l.clone());
-                new_required_columns.insert(r.clone());
+                new_required_columns.insert({
+                    let mut l = l.clone();
+                    l.name = l.name.to_ascii_lowercase();
+                    l
+                });
+                new_required_columns.insert({
+                    let mut r = r.clone();
+                    r.name = r.name.to_ascii_lowercase();
+                    r
+                });
             }
 
             let optimized_left = Arc::new(optimize_plan(

--- a/datafusion/core/src/physical_plan/functions.rs
+++ b/datafusion/core/src/physical_plan/functions.rs
@@ -755,15 +755,7 @@ where
             .map(|arg| arg.clone().into_array(num_rows))
             .collect::<Vec<ArrayRef>>();
 
-        let result = (inner)(&args);
-
-        let to_return: (ArrayRef, Vec<usize>) = result
-            .iter()
-            .map(|(r, indexes)| (r.clone(), indexes.clone()))
-            .next()
-            .unwrap();
-
-        Ok(to_return)
+        Ok((inner)(&args)?)
     })
 }
 

--- a/datafusion/core/src/physical_plan/join_utils.rs
+++ b/datafusion/core/src/physical_plan/join_utils.rs
@@ -54,10 +54,25 @@ fn check_join_set_is_valid(
     right: &HashSet<Column>,
     on: &[(Column, Column)],
 ) -> Result<()> {
-    let on_left = &on.iter().map(|on| on.0.clone()).collect::<HashSet<_>>();
+    let left = &left
+        .iter()
+        .map(|column| Column::new(&column.name().to_ascii_lowercase(), column.index()))
+        .collect();
+    let right = &right
+        .iter()
+        .map(|column| Column::new(&column.name().to_ascii_lowercase(), column.index()))
+        .collect();
+
+    let on_left = &on
+        .iter()
+        .map(|on| Column::new(&on.0.name().to_ascii_lowercase(), on.0.index()))
+        .collect::<HashSet<_>>();
     let left_missing = on_left.difference(left).collect::<HashSet<_>>();
 
-    let on_right = &on.iter().map(|on| on.1.clone()).collect::<HashSet<_>>();
+    let on_right = &on
+        .iter()
+        .map(|on| Column::new(&on.1.name().to_ascii_lowercase(), on.1.index()))
+        .collect::<HashSet<_>>();
     let right_missing = on_right.difference(right).collect::<HashSet<_>>();
 
     if !left_missing.is_empty() | !right_missing.is_empty() {

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -982,7 +982,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // create proxy node to handle udtfs and rewrite udtfs to columns (returning by TableUDFs Node)
         let udtf_exprs = find_udtf_exprs(select_exprs.as_slice());
         if !udtf_exprs.is_empty() {
-            plan = table_udfs(plan, udtf_exprs).unwrap();
+            plan = table_udfs(plan, udtf_exprs)?;
             select_exprs = rewrite_udtfs_to_columns(
                 select_exprs,
                 plan.schema().clone().as_ref().to_owned(),

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "47a7b66c64417662c6c30f0decdb0a900fc97a56" }

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573" }
 cranelift = "0.82.0"
 cranelift-jit = "0.82.0"
 cranelift-module = "0.82.0"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,7 +40,7 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "01aa59d11110fd33b389cab0bf679b99db9e10e2", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "52d28cdd32e7b7fb9997a2e6bb187f0a64392573", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }


### PR DESCRIPTION
This PR normalizes column names for joins in ProjectionPushDown, adding support for joins with an aliased FROM subquery and uppercase column names.
It also [bumps `arrow-rs`](https://github.com/cube-js/arrow-rs/commit/52d28cdd32e7b7fb9997a2e6bb187f0a64392573) to fix column search with uppercase aliases by normalizing field names before searching.
Additionally, it fixes UDTF error handling to propagate to protocol errors instead of unsafely unwrapping them.