### PR TITLE
fix(cubesql): Fix data loss on `JOIN` with `AND` + `OR`

### DIFF
--- a/datafusion/core/src/physical_plan/hash_join.rs
+++ b/datafusion/core/src/physical_plan/hash_join.rs
@@ -189,6 +189,12 @@ impl HashJoinExec {
     ) -> Result<Self> {
         let left_schema = left.schema();
         let right_schema = right.schema();
+        if on.is_empty() {
+            return Err(DataFusionError::Plan(
+                "On constraints in HashJoinExec should be non-empty".to_string(),
+            ));
+        }
+
         check_join_is_valid(&left_schema, &right_schema, &on)?;
 
         let (schema, column_indices) =

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -560,7 +560,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                     keys.into_iter().unzip();
 
                 // return the logical plan representing the join
-                if filter.is_empty() {
+                if left_keys.is_empty() {
+                    // When we don't have join keys, use cross join
+                    let join = LogicalPlanBuilder::from(left).cross_join(&right)?;
+
+                    join.filter(filter.into_iter().reduce(Expr::and).unwrap())?
+                        .build()
+                } else if filter.is_empty() {
                     let join = LogicalPlanBuilder::from(left).join(
                         &right,
                         join_type,
@@ -573,13 +579,8 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                         join_type,
                         (left_keys, right_keys),
                     )?;
-                    let join_filter_init = filter.remove(0);
-                    join.filter(
-                        filter
-                            .into_iter()
-                            .fold(join_filter_init, |acc, e| acc.and(e)),
-                    )?
-                    .build()
+                    join.filter(filter.into_iter().reduce(Expr::and).unwrap())?
+                        .build()
                 }
                 // Left join with all non-equijoin expressions from the right
                 // l left join r

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2494,17 +2494,8 @@ fn extract_join_keys(
                     extract_join_keys(*right, accum, accum_filter);
                 }
             }
-            _other
-                if matches!(**left, Expr::Column(_))
-                    || matches!(**right, Expr::Column(_)) =>
-            {
-                accum_filter.push(expr);
-            }
             _other => {
-                if let Expr::BinaryExpr { left, op: _, right } = expr {
-                    extract_join_keys(*left, accum, accum_filter);
-                    extract_join_keys(*right, accum, accum_filter);
-                }
+                accum_filter.push(expr);
             }
         },
         _other => {
@@ -4447,6 +4438,32 @@ mod tests {
                         \n    TableScan: person projection=None\
                         \n    Projection: ^#person.age + Int64(1)\
                         \n      EmptyRelation";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn join_on_disjunction_condition() {
+        let sql = "SELECT id, order_id \
+            FROM person \
+            JOIN orders ON id = customer_id OR person.age > 30";
+        let expected = "Projection: #person.id, #orders.order_id\
+            \n  Filter: #person.id = #orders.customer_id OR #person.age > Int64(30)\
+            \n    CrossJoin:\
+            \n      TableScan: person projection=None\
+            \n      TableScan: orders projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn join_on_complex_condition() {
+        let sql = "SELECT id, order_id \
+            FROM person \
+            JOIN orders ON id = customer_id AND (person.age > 30 OR person.last_name = 'X')";
+        let expected = "Projection: #person.id, #orders.order_id\
+            \n  Filter: #person.age > Int64(30) OR #person.last_name = Utf8(\"X\")\
+            \n    Inner Join: #person.id = #orders.customer_id\
+            \n      TableScan: person projection=None\
+            \n      TableScan: orders projection=None";
         quick_test(sql, expected);
     }
 }

--- a/datafusion/core/tests/sql/joins.rs
+++ b/datafusion/core/tests/sql/joins.rs
@@ -294,6 +294,24 @@ async fn left_join_not_null_filter_on_join_column() -> Result<()> {
 }
 
 #[tokio::test]
+async fn self_join_non_equijoin() -> Result<()> {
+    let ctx = create_join_context_with_nulls()?;
+    let sql =
+        "SELECT x.t1_id, y.t1_id FROM t1 x JOIN t1 y ON x.t1_id = 11 AND y.t1_id = 44";
+    let expected = vec![
+        "+-------+-------+",
+        "| t1_id | t1_id |",
+        "+-------+-------+",
+        "| 11    | 44    |",
+        "+-------+-------+",
+    ];
+
+    let actual = execute_to_batches(&ctx, sql).await;
+    assert_batches_eq!(expected, &actual);
+    Ok(())
+}
+
+#[tokio::test]
 async fn right_join_null_filter() -> Result<()> {
     let ctx = create_join_context_with_nulls()?;
     let sql = "SELECT t1_id, t1_name, t2_id FROM t1 RIGHT JOIN t2 ON t1_id = t2_id WHERE t1_name IS NULL ORDER BY t2_id";


### PR DESCRIPTION
This PR fixes queries that use `JOIN` with `AND` and `OR` over the same field and lose data, returning 0 rows.