### PR TITLE
fix: Correct UDTF behavior when no batch sections are present

### DIFF
--- a/datafusion/core/src/physical_plan/table_fun.rs
+++ b/datafusion/core/src/physical_plan/table_fun.rs
@@ -280,6 +280,10 @@ impl TableFunStream {
             }
         }
 
+        if max_batch_sizes.is_empty() {
+            return Ok(RecordBatch::new_empty(self.schema.clone()));
+        }
+
         let mut columns: Vec<ArrayRef> = Vec::new();
 
         for (col_i, ((col_arr, cur_batch_sizes), is_table_fun)) in


### PR DESCRIPTION
This PR fixes behavior of `TableFunStream` when no batch sections are present. Previously, sections would be passed to `arrow`'s `concat` which intentionally does not handle empty arrays. An introduced fix eliminates the issue by checking if there are any sections first, returning an empty batch for the case.