### PR TITLE
chore: Bump cube-js/sqlparser-rs@952bb1b

### DIFF
--- a/ballista/rust/client/Cargo.toml
+++ b/ballista/rust/client/Cargo.toml
@@ -35,7 +35,7 @@ datafusion = { path = "../../../datafusion/core", version = "7.0.0" }
 futures = "0.3"
 log = "0.4"
 parking_lot = "0.12"
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ca8131c36325e86fd733f337673e6cae5e946711" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "952bb1bdec0b3045d05b36bbd955770a931ed094" }
 tempfile = "3"
 tokio = "1.0"
 

--- a/ballista/rust/core/Cargo.toml
+++ b/ballista/rust/core/Cargo.toml
@@ -49,7 +49,7 @@ parse_arg = "0.1.3"
 prost = "0.9"
 prost-types = "0.9"
 serde = { version = "1", features = ["derive"] }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ca8131c36325e86fd733f337673e6cae5e946711" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "952bb1bdec0b3045d05b36bbd955770a931ed094" }
 tokio = "1.0"
 tonic = "0.6"
 uuid = { version = "0.8", features = ["v4"] }

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -44,4 +44,4 @@ cranelift-module = { version = "0.82.0", optional = true }
 ordered-float = "2.10"
 parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "bf19359d1a5cf6e2a96dec805a0bd4da1c30df5e", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ca8131c36325e86fd733f337673e6cae5e946711" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "952bb1bdec0b3045d05b36bbd955770a931ed094" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -78,7 +78,7 @@ pin-project-lite= "^0.2.7"
 pyo3 = { version = "0.16", optional = true }
 rand = "0.8"
 smallvec = { version = "1.6", features = ["union"] }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ca8131c36325e86fd733f337673e6cae5e946711" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "952bb1bdec0b3045d05b36bbd955770a931ed094" }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-stream = "0.1"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -38,4 +38,4 @@ path = "src/lib.rs"
 ahash = { version = "0.7", default-features = false }
 arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "bf19359d1a5cf6e2a96dec805a0bd4da1c30df5e", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "ca8131c36325e86fd733f337673e6cae5e946711" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "952bb1bdec0b3045d05b36bbd955770a931ed094" }


### PR DESCRIPTION
This PR bumps `sqlparser-rs` to support `LOCALTIME` and `LOCALTIMESTAMP` as parentheses-less functions like `CURRENT_TIMESTAMP`.