### PR TITLE
chore: Bump cube-js/sqlparser-rs@13aff89

### DIFF
--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -44,4 +44,4 @@ cranelift-module = { version = "0.82.0", optional = true }
 ordered-float = "2.10"
 parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "0a23deccf4e589768177fbaa7a3745c8b25f63c9", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "4b67b56c590ce5d4b0a7706e28ffa4209dadc770" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "13aff89fcbc3545c92a94ce771bafa739363fad5" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -79,7 +79,7 @@ pin-project-lite= "^0.2.7"
 pyo3 = { version = "0.16", optional = true }
 rand = "0.8"
 smallvec = { version = "1.6", features = ["union"] }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "4b67b56c590ce5d4b0a7706e28ffa4209dadc770" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "13aff89fcbc3545c92a94ce771bafa739363fad5" }
 tempfile = "3"
 tokio = { version = "1.0", features = ["macros", "rt", "rt-multi-thread", "sync", "fs", "parking_lot"] }
 tokio-stream = "0.1"

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -38,4 +38,4 @@ path = "src/lib.rs"
 ahash = { version = "0.7", default-features = false }
 arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "0a23deccf4e589768177fbaa7a3745c8b25f63c9", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
-sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "4b67b56c590ce5d4b0a7706e28ffa4209dadc770" }
+sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "13aff89fcbc3545c92a94ce771bafa739363fad5" }


### PR DESCRIPTION
This PR bumps `sqlparser-rs` in order to fix `INTERVAL` syntax parsing with non-PostgreSQL dialects.