### PR TITLE
chore: Bump cube-js/arrow-rs@9025ed8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=9025ed8fe15569b60daa6a148775334289b2f442#9025ed8fe15569b60daa6a148775334289b2f442"
 dependencies = [
  "bitflags",
  "chrono",
@@ -97,6 +97,7 @@ dependencies = [
  "pyo3",
  "rand 0.8.5",
  "regex",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -122,7 +123,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=9025ed8fe15569b60daa6a148775334289b2f442#9025ed8fe15569b60daa6a148775334289b2f442"
 dependencies = [
  "arrow",
  "base64",
@@ -1686,7 +1687,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=9025ed8fe15569b60daa6a148775334289b2f442#9025ed8fe15569b60daa6a148775334289b2f442"
 dependencies = [
  "arrow",
  "base64",

--- a/datafusion-cli/Cargo.lock
+++ b/datafusion-cli/Cargo.lock
@@ -58,7 +58,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=9025ed8fe15569b60daa6a148775334289b2f442#9025ed8fe15569b60daa6a148775334289b2f442"
 dependencies = [
  "bitflags",
  "chrono",
@@ -74,6 +74,7 @@ dependencies = [
  "num",
  "rand",
  "regex",
+ "regex-syntax",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1174,7 +1175,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d0466eca208313f3a8b669794e0bdc920151e19e#d0466eca208313f3a8b669794e0bdc920151e19e"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=9025ed8fe15569b60daa6a148775334289b2f442#9025ed8fe15569b60daa6a148775334289b2f442"
 dependencies = [
  "arrow",
  "base64",
@@ -1346,9 +1347,9 @@ checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.25"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 rust-version = "1.59"
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442" }
 clap = { version = "3", features = ["derive", "cargo"] }
 datafusion = { path = "../datafusion/core", version = "7.0.0" }
 dirs = "4.0.0"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e" }
+arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442" }
 async-trait = "0.1.41"
 datafusion = { path = "../datafusion/core" }
 futures = "0.3"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -38,10 +38,10 @@ jit = ["cranelift-module"]
 pyarrow = ["pyo3"]
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["prettyprint"] }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.82.0", optional = true }
 ordered-float = "2.10"
-parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["arrow"], optional = true }
+parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "2b18e22a179770f1297896d52ae384f00949ab2a" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -55,7 +55,7 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["prettyprint"] }
 async-trait = "0.1.41"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 chrono = { version = "0.4", default-features = false }
@@ -73,7 +73,7 @@ num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
 ordered-float = "2.10"
 parking_lot = "0.12"
-parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["arrow"] }
+parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["arrow"] }
 paste = "^1.0"
 pin-project-lite= "^0.2.7"
 pyo3 = { version = "0.16", optional = true }

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["prettyprint"] }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/cube_ext/Cargo.toml
+++ b/datafusion/cube_ext/Cargo.toml
@@ -35,7 +35,7 @@ name = "cube_ext"
 path = "src/lib.rs"
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["prettyprint"] }
 chrono = { version = "0.4.16", package = "chrono", default-features = false, features = ["clock"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
 datafusion-expr = { path = "../expr", version = "7.0.0" }

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "2b18e22a179770f1297896d52ae384f00949ab2a" }

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442" }
 cranelift = "0.82.0"
 cranelift-jit = "0.82.0"
 cranelift-module = "0.82.0"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,7 +40,7 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d0466eca208313f3a8b669794e0bdc920151e19e", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "9025ed8fe15569b60daa6a148775334289b2f442", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4", default-features = false }


### PR DESCRIPTION
This PR bumps cube-js/arrow-rs@9025ed8, fixing an issue with `[NOT] [I]LIKE` operator not recognizing escape characters, thus being unable to match `_` or `%` symbols explicitly.