### PR TITLE
feat: Support `regexp_replace` default empty replacer

### DIFF
--- a/datafusion/core/src/physical_plan/functions.rs
+++ b/datafusion/core/src/physical_plan/functions.rs
@@ -609,6 +609,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
         }
         BuiltinScalarFunction::RegexpReplace => Signature::one_of(
             vec![
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Utf8]),
                 TypeSignature::Exact(vec![
                     DataType::Utf8,
                     DataType::Utf8,
@@ -2262,6 +2263,18 @@ mod tests {
                 lit(ScalarValue::Utf8(Some("i".to_string()))),
             ],
             Ok(Some("XabcABC")),
+            &str,
+            Utf8,
+            StringArray
+        );
+        #[cfg(feature = "regex_expressions")]
+        test_function!(
+            RegexpReplace,
+            &[
+                lit(ScalarValue::Utf8(Some("ABCabcABC".to_string()))),
+                lit(ScalarValue::Utf8(Some("(abc)".to_string()))),
+            ],
+            Ok(Some("ABCABC")),
             &str,
             Utf8,
             StringArray

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -837,6 +837,7 @@ async fn test_regex_expressions() -> Result<()> {
     test_expression!("regexp_replace('ABCabcABC', '(abc)', 'X', 'i')", "XabcABC");
     test_expression!("regexp_replace('foobarbaz', 'b..', 'X', 'g')", "fooXX");
     test_expression!("regexp_replace('foobarbaz', 'b..', 'X')", "fooXbaz");
+    test_expression!("regexp_replace('foobarbaz', 'b..')", "foobaz");
     test_expression!(
         "regexp_replace('foobarbaz', 'b(..)', 'X\\1Y', 'g')",
         "fooXarYXazY"

--- a/datafusion/expr/src/expr_fn.rs
+++ b/datafusion/expr/src/expr_fn.rs
@@ -443,6 +443,7 @@ mod test {
             replacement,
             flags
         );
+        test_nary_scalar_expr!(RegexpReplace, regexp_replace, string, pattern);
         test_scalar_expr!(Replace, replace, string, from, to);
         test_scalar_expr!(Repeat, repeat, string, count);
         test_scalar_expr!(Reverse, reverse, string);


### PR DESCRIPTION
This PR adds support for two-argument `regexp_replace` variant where the replacer is missing and is assumed to be an empty string. Related tests are added.