### PR TITLE
chore: Improve Thoughtspot Postgres compatibility

### DIFF
--- a/datafusion/core/src/physical_plan/functions.rs
+++ b/datafusion/core/src/physical_plan/functions.rs
@@ -515,6 +515,7 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Utf8,
                     DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_owned())),
                 ]),
+                TypeSignature::Exact(vec![DataType::Utf8, DataType::Date32]),
             ],
             fun.volatility(),
         ),

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -442,6 +442,11 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 tz_opt.clone(),
             ))
         }
+        ColumnarValue::Scalar(ScalarValue::Date32(_)) => {
+            return Err(DataFusionError::Execution(
+                "`date_trunc` does not accept Date32 type, it's a stub".to_string(),
+            ));
+        }
         ColumnarValue::Array(array) => {
             let array = array
                 .as_any()


### PR DESCRIPTION
This PR adds changes that improve Thoughtspot compatibility:

- Allow `Date32` as an argument to `date_trunc` in initial plan
- Allow `Date32 - Date32` expressions in initial plan
