### PR TITLE
feat: Support `Date32` to `TimestampNanosecond` coercion

### DIFF
--- a/datafusion/core/src/physical_plan/functions.rs
+++ b/datafusion/core/src/physical_plan/functions.rs
@@ -516,7 +516,6 @@ fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Utf8,
                     DataType::Timestamp(TimeUnit::Nanosecond, Some("UTC".to_owned())),
                 ]),
-                TypeSignature::Exact(vec![DataType::Utf8, DataType::Date32]),
             ],
             fun.volatility(),
         ),

--- a/datafusion/core/src/physical_plan/type_coercion.rs
+++ b/datafusion/core/src/physical_plan/type_coercion.rs
@@ -201,7 +201,9 @@ pub fn can_coerce_from(type_into: &DataType, type_from: &DataType) -> bool {
                 | Float32
                 | Float64
         ),
-        Timestamp(TimeUnit::Nanosecond, None) => matches!(type_from, Timestamp(_, None)),
+        Timestamp(TimeUnit::Nanosecond, None) => {
+            matches!(type_from, Timestamp(_, None) | Date32)
+        }
         Utf8 | LargeUtf8 => true,
         _ => false,
     }

--- a/datafusion/core/tests/sql/timestamp.rs
+++ b/datafusion/core/tests/sql/timestamp.rs
@@ -846,3 +846,34 @@ async fn test_current_date() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn date_trunc_date32_test() -> Result<()> {
+    let ctx = SessionContext::new();
+
+    let sql = "select date_trunc('month', cast('2023-02-28' as date)) as dt";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+---------------------+",
+        "| dt                  |",
+        "+---------------------+",
+        "| 2023-02-01 00:00:00 |",
+        "+---------------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    let sql = "with w as (select cast('2023-02-28' as date) d) select date_trunc('month', d) as dt from w";
+    let results = execute_to_batches(&ctx, sql).await;
+
+    let expected = vec![
+        "+---------------------+",
+        "| dt                  |",
+        "+---------------------+",
+        "| 2023-02-01 00:00:00 |",
+        "+---------------------+",
+    ];
+    assert_batches_eq!(expected, &results);
+
+    Ok(())
+}

--- a/datafusion/physical-expr/src/datetime_expressions.rs
+++ b/datafusion/physical-expr/src/datetime_expressions.rs
@@ -460,11 +460,6 @@ pub fn date_trunc(args: &[ColumnarValue]) -> Result<ColumnarValue> {
                 tz_opt.clone(),
             ))
         }
-        ColumnarValue::Scalar(ScalarValue::Date32(_)) => {
-            return Err(DataFusionError::Execution(
-                "`date_trunc` does not accept Date32 type, it's a stub".to_string(),
-            ));
-        }
         ColumnarValue::Array(array) => {
             let array = array
                 .as_any()


### PR DESCRIPTION
This PR extends `date_trunc` function, allowing `Date32` input as a second argument. Related tests are included.