### PR TITLE
feat: Add Utf8 coercion for intervals

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -644,6 +644,9 @@ impl ScalarValue {
                 | ScalarValue::TimestampMicrosecond(None, _)
                 | ScalarValue::TimestampNanosecond(None, _)
                 | ScalarValue::Struct(None, _)
+                | ScalarValue::IntervalDayTime(None)
+                | ScalarValue::IntervalYearMonth(None)
+                | ScalarValue::IntervalMonthDayNano(None)
                 | ScalarValue::Decimal128(None, _, _) // For decimal type, the value is null means ScalarValue::Decimal128 is null.
         )
     }
@@ -1739,6 +1742,15 @@ impl TryFrom<&DataType> for ScalarValue {
             }
             DataType::Struct(fields) => {
                 ScalarValue::Struct(None, Box::new(fields.clone()))
+            }
+            DataType::Interval(IntervalUnit::DayTime) => {
+                ScalarValue::IntervalDayTime(None)
+            }
+            DataType::Interval(IntervalUnit::YearMonth) => {
+                ScalarValue::IntervalYearMonth(None)
+            }
+            DataType::Interval(IntervalUnit::MonthDayNano) => {
+                ScalarValue::IntervalMonthDayNano(None)
             }
             _ => {
                 return Err(DataFusionError::NotImplemented(format!(

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -605,30 +605,24 @@ pub fn interval_coercion(
             _ => None,
         },
         Operator::Multiply => match (lhs_type, rhs_type) {
-            (Int64, Interval(itype)) | (Interval(itype), Int64) => {
-                Some(Interval(itype.clone()))
-            }
-            (Int32, Interval(itype)) | (Interval(itype), Int32) => {
-                Some(Interval(itype.clone()))
-            }
-            (Int16, Interval(itype)) | (Interval(itype), Int16) => {
-                Some(Interval(itype.clone()))
-            }
-            (Int8, Interval(itype)) | (Interval(itype), Int8) => {
-                Some(Interval(itype.clone()))
-            }
-            (UInt64, Interval(itype)) | (Interval(itype), UInt64) => {
-                Some(Interval(itype.clone()))
-            }
-            (UInt32, Interval(itype)) | (Interval(itype), UInt32) => {
-                Some(Interval(itype.clone()))
-            }
-            (UInt16, Interval(itype)) | (Interval(itype), UInt16) => {
-                Some(Interval(itype.clone()))
-            }
-            (UInt8, Interval(itype)) | (Interval(itype), UInt8) => {
-                Some(Interval(itype.clone()))
-            }
+            (Utf8, Interval(itype))
+            | (Interval(itype), Utf8)
+            | (Int64, Interval(itype))
+            | (Interval(itype), Int64)
+            | (Int32, Interval(itype))
+            | (Interval(itype), Int32)
+            | (Int16, Interval(itype))
+            | (Interval(itype), Int16)
+            | (Int8, Interval(itype))
+            | (Interval(itype), Int8)
+            | (UInt64, Interval(itype))
+            | (Interval(itype), UInt64)
+            | (UInt32, Interval(itype))
+            | (Interval(itype), UInt32)
+            | (UInt16, Interval(itype))
+            | (Interval(itype), UInt16)
+            | (UInt8, Interval(itype))
+            | (Interval(itype), UInt8) => Some(Interval(itype.clone())),
             _ => None,
         },
         _ => None,


### PR DESCRIPTION
This PR adds `Utf8 * Interval` coercion support. It also adds support for `Interval` types to be converted to a NULL `ScalarValue` instance of the respective type, and extends `ScalarValue::is_null` function to also return `true` for `Interval` types.