### PR TITLE
feat: Support planning extra expressions

### DIFF
--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -585,6 +585,7 @@ pub fn interval_coercion(
     rhs_type: &DataType,
 ) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
+    use arrow::datatypes::IntervalUnit::*;
 
     // these are ordered from most informative to least informative so
     // that the coercion removes the least amount of information
@@ -605,6 +606,10 @@ pub fn interval_coercion(
             _ => None,
         },
         Operator::Multiply => match (lhs_type, rhs_type) {
+            (Float64, Interval(_))
+            | (Interval(_), Float64)
+            | (Float32, Interval(_))
+            | (Interval(_), Float32) => Some(Interval(MonthDayNano)),
             (Utf8, Interval(itype))
             | (Interval(itype), Utf8)
             | (Int64, Interval(itype))

--- a/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
+++ b/datafusion/physical-expr/src/coercion_rule/binary_rule.rs
@@ -638,12 +638,14 @@ pub fn date_coercion(
     rhs_type: &DataType,
 ) -> Option<DataType> {
     use arrow::datatypes::DataType::*;
+    use arrow::datatypes::IntervalUnit::*;
 
     // these are ordered from most informative to least informative so
     // that the coercion removes the least amount of information
     match op {
         Operator::Minus => match (lhs_type, rhs_type) {
             (Date32, Date32) => Some(Int32),
+            (Timestamp(_, _), Timestamp(_, _)) => Some(Interval(MonthDayNano)),
             _ => None,
         },
         _ => None,


### PR DESCRIPTION
This PR allows planning (but not execution) of new expressions:
- `DatePart` with `Interval` as argument
- `Timestamp - Timestamp` binary expressions
- `Float * Interval` binary expressions