### PR TITLE
chore: Remove tokio 0.1 support for tracing

### DIFF
--- a/datafusion/Cargo.toml
+++ b/datafusion/Cargo.toml
@@ -74,7 +74,7 @@ serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 moka = "0.8.2"
 tracing = "0.1.25"
-tracing-futures = { version = "0.2.5", features = ["tokio", "tokio-executor"] }
+tracing-futures = { version = "0.2.5" }
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
```
tokio v0.1.22
└── tracing-futures v0.2.5
    ├── datafusion v4.0.0-SNAPSHOT (/Users/ovr/projects/cube/arrow-datafusion/datafusion)
    │   ├── arrow-benchmarks v4.0.0-SNAPSHOT (/Users/ovr/projects/cube/arrow-datafusion/benchmarks)
    │   └── datafusion-cli v4.0.0-SNAPSHOT (/Users/ovr/projects/cube/arrow-datafusion/datafusion-cli)
    │   [dev-dependencies]
    │   └── datafusion-examples v4.0.0-SNAPSHOT (/Users/ovr/projects/cube/arrow-datafusion/datafusion-examples)
    └── tonic v0.4.3
        └── arrow-flight v5.0.0 (https://github.com/cube-js/arrow-rs.git?branch=cube#ba5455c2)
            [dev-dependencies]
            └── datafusion-examples v4.0.0-SNAPSHOT (/Users/ovr/projects/cube/arrow-datafusion/datafusion-examples)
        [dev-dependencies]
        └── datafusion-examples v4.0.0-SNAPSHOT (/Users/ovr/projects/cube/arrow-datafusion/datafusion-examples)

```