### PR TITLE
feat: Support `MonthDayNano` interval int multiply

### DIFF
--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2615,21 +2615,33 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             }
 
             match interval_type.to_lowercase().as_str() {
-                "year" => Ok(align_interval_parts(interval_period * 12_f32, 0.0, 0.0)),
-                "quarter" => Ok(align_interval_parts(interval_period * 3_f32, 0.0, 0.0)),
-                "month" => Ok(align_interval_parts(interval_period, 0.0, 0.0)),
-                "week" | "weeks" => {
+                "years" | "year" | "y" => {
+                    Ok(align_interval_parts(interval_period * 12_f32, 0.0, 0.0))
+                }
+                "quarter" | "qtr" => {
+                    Ok(align_interval_parts(interval_period * 3_f32, 0.0, 0.0))
+                }
+                "months" | "month" | "mons" | "mon" => {
+                    Ok(align_interval_parts(interval_period, 0.0, 0.0))
+                }
+                "weeks" | "week" | "w" => {
                     Ok(align_interval_parts(0.0, interval_period * 7_f32, 0.0))
                 }
-                "day" | "days" => Ok(align_interval_parts(0.0, interval_period, 0.0)),
-                "hour" | "hours" => {
+                "days" | "day" | "d" => {
+                    Ok(align_interval_parts(0.0, interval_period, 0.0))
+                }
+                "hours" | "hour" | "h" => {
                     Ok((0, 0, interval_period * SECONDS_PER_HOUR * MILLIS_PER_SECOND))
                 }
-                "minutes" | "minute" => {
+                "minutes" | "minute" | "mins" | "min" | "m" => {
                     Ok((0, 0, interval_period * 60_f32 * MILLIS_PER_SECOND))
                 }
-                "seconds" | "second" => Ok((0, 0, interval_period * MILLIS_PER_SECOND)),
-                "milliseconds" | "millisecond" => Ok((0, 0, interval_period)),
+                "seconds" | "second" | "secs" | "sec" | "s" => {
+                    Ok((0, 0, interval_period * MILLIS_PER_SECOND))
+                }
+                "milliseconds" | "millisecond" | "msecs" | "msec" | "ms" => {
+                    Ok((0, 0, interval_period))
+                }
                 _ => Err(DataFusionError::NotImplemented(format!(
                     "Invalid input syntax for type interval: {:?}",
                     value

--- a/datafusion/core/tests/sql/expr.rs
+++ b/datafusion/core/tests/sql/expr.rs
@@ -699,6 +699,28 @@ async fn test_interval_expressions() -> Result<()> {
         "interval '1 year 1 day 1 hour 1 minute 1 second'",
         "0 years 12 mons 1 days 1 hours 1 mins 1.000000000 secs"
     );
+    test_expression!(
+        "interval '23 years 123 months 75 days 25 hours 73 mins 125 secs 1234 ms'",
+        "0 years 399 mons 75 days 26 hours 15 mins 6.234000000 secs"
+    );
+    test_expression!(
+        "11 * interval '0 years 2 months 75 days 25 hours 73 mins 125 secs 1234 ms'",
+        "0 years 22 mons 825 days 288 hours 46 mins 8.574000000 secs"
+    );
+    // TODO: f32 persicion problem in `fn sql_interval_to_literal`
+    // test_expression!(
+    //     "interval '1 mon 87654321 ms'",
+    //     "0 years 1 mons 0 days 24 hours 20 mins 54.321000000 secs"
+    // );
+    test_expression!(
+        "12345 * interval '2 years 2 months 3 days 13 hours 3 mins 3 secs 7654321 ms'",
+        "0 years 320970 mons 37035 days 187360 hours 28 mins 47.745000000 secs"
+    );
+    // NOTE: only fractional output is incorrect, the calculations under the hood are correct
+    test_expression!(
+        "5 * interval '-1 month -1 day -1 millisecond'",
+        "0 years -5 mons -5 days 0 hours 0 mins 0.-05000000 secs"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
This PR adds support for `Interval(MonthDayNano) * Int64` expression evaluation with tests included.
It also adds coercion for `Interval + Interval` or `Interval - Interval` expressions.