### PR TITLE
chore: Break sql_expr_to_logical_expr into smaller parts

### DIFF
--- a/datafusion/core/src/lib.rs
+++ b/datafusion/core/src/lib.rs
@@ -14,6 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+#![feature(stmt_expr_attributes)]
 #![warn(missing_docs, clippy::needless_borrow)]
 
 //! [DataFusion](https://github.com/apache/arrow-datafusion)


### PR DESCRIPTION
    
    This avoids stack overflow in debug builds, because rustc seemingly
    picks unique locations for every variable and temporary instead of
    using the same stack locations in different branches, in non-optimized
    builds.
    
    In release mode, the closures are inlined (and the attributes are
    necessary to make it happen; otherwise the compiler generates a direct
    function call.)
    
    By using closures, we avoid a large diff.  Maybe upstream changes
    would merge more easily.  Inline function declarations (using fn)
    would have a larger diff because they can't use the keyword 'self'.

