### PR TITLE
refactor: Use arrow interval packing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 [[package]]
 name = "arrow"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=db18b5c398ba5554fc774544cec4b713445102bf#db18b5c398ba5554fc774544cec4b713445102bf"
 dependencies = [
  "bitflags",
  "chrono",
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "arrow-flight"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=db18b5c398ba5554fc774544cec4b713445102bf#db18b5c398ba5554fc774544cec4b713445102bf"
 dependencies = [
  "arrow",
  "base64",
@@ -1688,7 +1688,7 @@ dependencies = [
 [[package]]
 name = "parquet"
 version = "11.1.0"
-source = "git+https://github.com/cube-js/arrow-rs.git?rev=d9c12d71b655d356c5a287226a763638417972e9#d9c12d71b655d356c5a287226a763638417972e9"
+source = "git+https://github.com/cube-js/arrow-rs.git?rev=db18b5c398ba5554fc774544cec4b713445102bf#db18b5c398ba5554fc774544cec4b713445102bf"
 dependencies = [
  "arrow",
  "base64",

--- a/datafusion-cli/Cargo.toml
+++ b/datafusion-cli/Cargo.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/apache/arrow-datafusion"
 rust-version = "1.59"
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf" }
 clap = { version = "3", features = ["derive", "cargo"] }
 datafusion = { path = "../datafusion/core", version = "7.0.0" }
 dirs = "4.0.0"

--- a/datafusion-examples/Cargo.toml
+++ b/datafusion-examples/Cargo.toml
@@ -34,7 +34,7 @@ path = "examples/avro_sql.rs"
 required-features = ["datafusion/avro"]
 
 [dev-dependencies]
-arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9" }
+arrow-flight = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf" }
 async-trait = "0.1.41"
 datafusion = { path = "../datafusion/core" }
 futures = "0.3"

--- a/datafusion/common/Cargo.toml
+++ b/datafusion/common/Cargo.toml
@@ -38,10 +38,10 @@ jit = ["cranelift-module"]
 pyarrow = ["pyo3"]
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["prettyprint"] }
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 cranelift-module = { version = "0.82.0", optional = true }
 ordered-float = "2.10"
-parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["arrow"], optional = true }
+parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["arrow"], optional = true }
 pyo3 = { version = "0.16", optional = true }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "6a54d27d3b75a04b9f9cbe309a83078aa54b32fd" }

--- a/datafusion/core/Cargo.toml
+++ b/datafusion/core/Cargo.toml
@@ -55,7 +55,7 @@ unicode_expressions = ["datafusion-physical-expr/regex_expressions"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["prettyprint"] }
 async-trait = "0.1.41"
 avro-rs = { version = "0.13", features = ["snappy"], optional = true }
 chrono = { version = "0.4", default-features = false }
@@ -73,7 +73,7 @@ num-traits = { version = "0.2", optional = true }
 num_cpus = "1.13.0"
 ordered-float = "2.10"
 parking_lot = "0.12"
-parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["arrow"] }
+parquet = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["arrow"] }
 paste = "^1.0"
 pin-project-lite= "^0.2.7"
 pyo3 = { version = "0.16", optional = true }

--- a/datafusion/core/fuzz-utils/Cargo.toml
+++ b/datafusion/core/fuzz-utils/Cargo.toml
@@ -23,6 +23,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["prettyprint"] }
 env_logger = "0.9.0"
 rand = "0.8"

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2655,6 +2655,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
 
         let mut parts = value.split_whitespace();
 
+        let out_of_range = || {
+            DataFusionError::NotImplemented(format!(
+                "Interval field value out of range: {:?}",
+                value
+            ))
+        };
+
         loop {
             let interval_period_str = parts.next();
             if interval_period_str.is_none() {
@@ -2677,28 +2684,19 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             result_month += diff_month as i64;
 
             if result_month > (i32::MAX as i64) {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Interval field value out of range: {:?}",
-                    value
-                )));
+                return Err(out_of_range());
             }
 
             result_days += diff_days as i64;
 
             if result_days > (i32::MAX as i64) {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Interval field value out of range: {:?}",
-                    value
-                )));
+                return Err(out_of_range());
             }
 
             result_millis += diff_millis as i64;
 
             if result_millis > (i32::MAX as i64) {
-                return Err(DataFusionError::NotImplemented(format!(
-                    "Interval field value out of range: {:?}",
-                    value
-                )));
+                return Err(out_of_range());
             }
         }
 

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2614,6 +2614,13 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                 )));
             }
 
+            if interval_period < (i32::MIN as f32) {
+                return Err(DataFusionError::NotImplemented(format!(
+                    "Interval field value out of range: {:?}",
+                    value
+                )));
+            }
+
             match interval_type.to_lowercase().as_str() {
                 "years" | "year" | "y" => {
                     Ok(align_interval_parts(interval_period * 12_f32, 0.0, 0.0))

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -2706,11 +2706,12 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
         // The true way to store and calculate intervals is to store it as it defined
         // It's why we there are 3 different interval types in Arrow
         if result_month != 0 && (result_days != 0 || result_millis != 0) {
-            let result: i128 = ((result_month as i128) << 96)
-                | ((result_days as i128) << 64)
-                // IntervalMonthDayNano uses nanos, but IntervalDayTime uses milles
-                | ((result_millis as i64 * 1_000_000_i64) as i128);
-
+            let result = IntervalMonthDayNanoType::make_value(
+                result_month,
+                result_days,
+                // IntervalMonthDayNano uses nanos, but IntervalDayTime uses millis
+                result_millis as i64 * 1_000_000_i64,
+            );
             return Ok(Expr::Literal(ScalarValue::IntervalMonthDayNano(Some(
                 result,
             ))));
@@ -2723,7 +2724,7 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
             ))));
         }
 
-        let result: i64 = ((result_days as i64) << 32) | result_millis as i64;
+        let result = IntervalDayTimeType::make_value(result_days, result_millis);
         Ok(Expr::Literal(ScalarValue::IntervalDayTime(Some(result))))
     }
 

--- a/datafusion/cube_ext/Cargo.toml
+++ b/datafusion/cube_ext/Cargo.toml
@@ -35,7 +35,7 @@ name = "cube_ext"
 path = "src/lib.rs"
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["prettyprint"] }
 chrono = { version = "0.4.16", package = "chrono", default-features = false, features = ["clock"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
 datafusion-expr = { path = "../expr", version = "7.0.0" }

--- a/datafusion/expr/Cargo.toml
+++ b/datafusion/expr/Cargo.toml
@@ -36,6 +36,6 @@ path = "src/lib.rs"
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["prettyprint"] }
 datafusion-common = { path = "../common", version = "7.0.0" }
 sqlparser = { git = 'https://github.com/cube-js/sqlparser-rs.git', rev = "6a54d27d3b75a04b9f9cbe309a83078aa54b32fd" }

--- a/datafusion/jit/Cargo.toml
+++ b/datafusion/jit/Cargo.toml
@@ -36,7 +36,7 @@ path = "src/lib.rs"
 jit = []
 
 [dependencies]
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9" }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf" }
 cranelift = "0.82.0"
 cranelift-jit = "0.82.0"
 cranelift-module = "0.82.0"

--- a/datafusion/physical-expr/Cargo.toml
+++ b/datafusion/physical-expr/Cargo.toml
@@ -40,7 +40,7 @@ unicode_expressions = ["unicode-segmentation"]
 
 [dependencies]
 ahash = { version = "0.7", default-features = false }
-arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "d9c12d71b655d356c5a287226a763638417972e9", features = ["prettyprint"] }
+arrow = { git = 'https://github.com/cube-js/arrow-rs.git', rev = "db18b5c398ba5554fc774544cec4b713445102bf", features = ["prettyprint"] }
 blake2 = { version = "^0.10.2", optional = true }
 blake3 = { version = "1.0", optional = true }
 chrono = { version = "0.4.20", default-features = false }

--- a/datafusion/physical-expr/src/expressions/binary_distinct.rs
+++ b/datafusion/physical-expr/src/expressions/binary_distinct.rs
@@ -604,11 +604,13 @@ fn duration_to_interval_day_nano(
     })?;
 
     let days = nanos / 86_400_000_000_000;
+    let days = i32::try_from(days).map_err(|_| {
+        DataFusionError::Execution("Interval value is out of range".to_string())
+    })?;
     let nanos_rem = nanos % 86_400_000_000_000;
-    Ok(Some(
-        (((days as i128) & 0xFFFF_FFFF) << 64)
-            | ((nanos_rem as i128) & 0xFFFF_FFFF_FFFF_FFFF),
-    ))
+    Ok(Some(IntervalMonthDayNanoType::make_value(
+        0, days, nanos_rem,
+    )))
 }
 
 fn change_ym(t: NaiveDateTime, y: i32, m: u32) -> Result<NaiveDateTime> {

--- a/datafusion/physical-expr/src/expressions/binary_distinct.rs
+++ b/datafusion/physical-expr/src/expressions/binary_distinct.rs
@@ -23,8 +23,9 @@ use arrow::{
         IntervalMonthDayNanoArray, IntervalYearMonthArray, TimestampNanosecondArray,
     },
     datatypes::{
-        ArrowPrimitiveType, DataType, IntervalDayTimeType, IntervalMonthDayNanoType,
-        IntervalUnit, IntervalYearMonthType,
+        ArrowPrimitiveType, DataType, Date32Type, IntervalDayTimeType,
+        IntervalMonthDayNanoType, IntervalUnit, IntervalYearMonthType,
+        TimestampNanosecondType,
     },
     temporal_conversions::{date32_to_datetime, timestamp_ns_to_datetime},
 };
@@ -32,6 +33,8 @@ use chrono::{Datelike, Days, Duration, Months, NaiveDate, NaiveDateTime};
 use datafusion_common::{DataFusionError, Result};
 use datafusion_expr::Operator;
 
+type TimestampNanosecond = <TimestampNanosecondType as ArrowPrimitiveType>::Native;
+type Date32 = <Date32Type as ArrowPrimitiveType>::Native;
 type IntervalYearMonth = <IntervalYearMonthType as ArrowPrimitiveType>::Native;
 type IntervalDayTime = <IntervalDayTimeType as ArrowPrimitiveType>::Native;
 type IntervalMonthDayNano = <IntervalMonthDayNanoType as ArrowPrimitiveType>::Native;
@@ -453,10 +456,10 @@ fn timestamp_subtract_date(
 }
 
 fn scalar_timestamp_add_interval_year_month(
-    timestamp: Option<i64>,
+    timestamp: Option<TimestampNanosecond>,
     interval: Option<IntervalYearMonth>,
     negated: bool,
-) -> Result<Option<i64>> {
+) -> Result<Option<TimestampNanosecond>> {
     if timestamp.is_none() || interval.is_none() {
         return Ok(None);
     }
@@ -493,10 +496,10 @@ fn scalar_timestamp_add_interval_year_month(
 }
 
 fn scalar_timestamp_add_interval_day_time(
-    timestamp: Option<i64>,
+    timestamp: Option<TimestampNanosecond>,
     interval: Option<IntervalDayTime>,
     negated: bool,
-) -> Result<Option<i64>> {
+) -> Result<Option<TimestampNanosecond>> {
     if timestamp.is_none() || interval.is_none() {
         return Ok(None);
     }
@@ -519,10 +522,10 @@ fn scalar_timestamp_add_interval_day_time(
 }
 
 fn scalar_timestamp_add_interval_month_day_nano(
-    timestamp: Option<i64>,
+    timestamp: Option<TimestampNanosecond>,
     interval: Option<IntervalMonthDayNano>,
     negated: bool,
-) -> Result<Option<i64>> {
+) -> Result<Option<TimestampNanosecond>> {
     if timestamp.is_none() || interval.is_none() {
         return Ok(None);
     }
@@ -560,8 +563,8 @@ fn scalar_timestamp_add_interval_month_day_nano(
 }
 
 fn scalar_timestamp_subtract_timestamp(
-    timestamp_left: Option<i64>,
-    timestamp_right: Option<i64>,
+    timestamp_left: Option<TimestampNanosecond>,
+    timestamp_right: Option<TimestampNanosecond>,
 ) -> Result<Option<IntervalMonthDayNano>> {
     if timestamp_left.is_none() || timestamp_right.is_none() {
         return Ok(None);
@@ -578,8 +581,8 @@ fn scalar_timestamp_subtract_timestamp(
 }
 
 fn scalar_timestamp_subtract_date(
-    timestamp_left: Option<i64>,
-    timestamp_right: Option<i32>,
+    timestamp_left: Option<TimestampNanosecond>,
+    timestamp_right: Option<Date32>,
 ) -> Result<Option<IntervalMonthDayNano>> {
     if timestamp_left.is_none() || timestamp_right.is_none() {
         return Ok(None);


### PR DESCRIPTION
I've skimmed through code looking for anything that looked like bit packing for intervals, replaced it with `to_parts` and `make_value` from arrow,  fixed some of overflow/underflow handling and used named type aliases in place of underlying integers

TODO: reference proper commit in `Bump arrow` after https://github.com/cube-js/arrow-rs/pull/37 is merged