### PR TITLE
feat: Support `Null` input type in `Sum` and `Avg` functions

### DIFF
--- a/datafusion/expr/src/aggregate_function.rs
+++ b/datafusion/expr/src/aggregate_function.rs
@@ -419,6 +419,7 @@ pub fn sum_return_type(arg_type: &DataType) -> Result<DataType> {
             let new_precision = DECIMAL_MAX_PRECISION.min(*precision + 10);
             Ok(DataType::Decimal(new_precision, *scale))
         }
+        DataType::Null => Ok(DataType::Null),
         other => Err(DataFusionError::Plan(format!(
             "SUM does not support type \"{:?}\"",
             other
@@ -526,6 +527,7 @@ pub fn avg_return_type(arg_type: &DataType) -> Result<DataType> {
         | DataType::UInt64
         | DataType::Float32
         | DataType::Float64 => Ok(DataType::Float64),
+        DataType::Null => Ok(DataType::Null),
         other => Err(DataFusionError::Plan(format!(
             "AVG does not support {:?}",
             other
@@ -616,6 +618,7 @@ pub fn is_sum_support_arg_type(arg_type: &DataType) -> bool {
             | DataType::Float32
             | DataType::Float64
             | DataType::Decimal(_, _)
+            | DataType::Null
     )
 }
 
@@ -633,6 +636,7 @@ pub fn is_avg_support_arg_type(arg_type: &DataType) -> bool {
             | DataType::Float32
             | DataType::Float64
             | DataType::Decimal(_, _)
+            | DataType::Null
     )
 }
 
@@ -778,6 +782,7 @@ mod tests {
             vec![DataType::Int32],
             vec![DataType::Float32],
             vec![DataType::Decimal(20, 3)],
+            vec![DataType::Null],
         ];
         for fun in funs {
             for input_type in &input_types {

--- a/datafusion/physical-expr/src/expressions/average.rs
+++ b/datafusion/physical-expr/src/expressions/average.rs
@@ -52,7 +52,7 @@ impl Avg {
         // the result of avg just support FLOAT64 and Decimal data type.
         assert!(matches!(
             data_type,
-            DataType::Float64 | DataType::Decimal(_, _)
+            DataType::Float64 | DataType::Decimal(_, _) | DataType::Null
         ));
         Self {
             name: name.into(),
@@ -160,6 +160,7 @@ impl Accumulator for AvgAccumulator {
                     ),
                 })
             }
+            ScalarValue::Null => Ok(ScalarValue::Null),
             _ => Err(DataFusionError::Internal(
                 "Sum should be f64 on average".to_string(),
             )),
@@ -309,6 +310,12 @@ mod tests {
             ScalarValue::from(3_f64),
             DataType::Float64
         )
+    }
+
+    #[test]
+    fn avg_null_type() -> Result<()> {
+        let a: ArrayRef = Arc::new(NullArray::new(5));
+        generic_test_op!(a, DataType::Null, Avg, ScalarValue::Null, DataType::Null)
     }
 
     fn aggregate(


### PR DESCRIPTION
This PR adds support for planning and execution of aggregate functions `SUM` and `AVG` with input type of `Null`. The output type is `Null` as well. Related tests are included.