### PR TITLE
Improve cube_ext macro hygiene

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2023-08-03]
+        rust: [nightly-2024-01-29]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -73,7 +73,7 @@ jobs:
     strategy:
       matrix:
         arch: [amd64]
-        rust: [nightly-2023-08-03]
+        rust: [nightly-2024-01-29]
     container:
       image: ${{ matrix.arch }}/rust
       env:
@@ -199,7 +199,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest]
-        rust: [nightly-2023-08-03]
+        rust: [nightly-2024-01-29]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -230,8 +230,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup toolchain
         run: |
-          rustup toolchain install nightly-2023-08-03
-          rustup default nightly-2023-08-03
+          rustup toolchain install nightly-2024-01-29
+          rustup default nightly-2024-01-29
           rustup component add rustfmt
       - name: Run
         run: cargo fmt --all -- --check

--- a/datafusion/src/cube_ext/util.rs
+++ b/datafusion/src/cube_ext/util.rs
@@ -25,8 +25,8 @@ use std::cmp::Ordering;
 #[macro_export]
 macro_rules! cube_match_array {
     ($array: expr, $matcher: ident) => {{
-        use arrow::array::*;
-        use arrow::datatypes::*;
+        use $crate::arrow::array::*;
+        use $crate::arrow::datatypes::*;
         let a = $array;
         match a.data_type() {
             DataType::Null => panic!("null type is not supported"),
@@ -205,7 +205,7 @@ macro_rules! cube_match_array {
 #[macro_export]
 macro_rules! cube_match_scalar {
     ($scalar: expr, $matcher: ident $(, $arg: tt)*) => {{
-        use arrow::array::*;
+        use $crate::arrow::array::*;
         match $scalar {
             ScalarValue::Boolean(v) => ($matcher!($($arg ,)* v, BooleanBuilder)),
             ScalarValue::Float32(v) => ($matcher!($($arg ,)* v, Float32Builder)),


### PR DESCRIPTION
Use `$crate` to import `arrow` from `datafusion` crate, not from callee context

