### PR TITLE
fix: log and round function planning with second argument as int64

### DIFF
--- a/datafusion/core/tests/sql/functions.rs
+++ b/datafusion/core/tests/sql/functions.rs
@@ -612,14 +612,12 @@ async fn pi_function() -> Result<()> {
 }
 
 macro_rules! assert_logical_plan {
-    ($ctx:expr, $udf_call:expr, $expected:expr) => {
-        {
-            let sql = format!("SELECT {}", $udf_call);
-            let logical_plan = $ctx.create_logical_plan(&sql)?;
-            let formatted = format!("{:?}", logical_plan);
-            assert_eq!($expected, formatted.split("\n").collect::<Vec<&str>>());
-        }
-    };
+    ($ctx:expr, $udf_call:expr, $expected:expr) => {{
+        let sql = format!("SELECT {}", $udf_call);
+        let logical_plan = $ctx.create_logical_plan(&sql)?;
+        let formatted = format!("{:?}", logical_plan);
+        assert_eq!($expected, formatted.split("\n").collect::<Vec<&str>>());
+    }};
 }
 
 #[tokio::test]
@@ -629,10 +627,7 @@ async fn test_log_round_logical_plan() -> Result<()> {
     assert_logical_plan!(
         ctx,
         "log(2.0, 2)",
-        vec![
-            "Projection: log(Float64(2), Int64(2))",
-            "  EmptyRelation",
-        ]
+        vec!["Projection: log(Float64(2), Int64(2))", "  EmptyRelation",]
     );
 
     assert_logical_plan!(

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -559,6 +559,8 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                     DataType::Decimal(38, 10),
                     DataType::Decimal(38, 10),
                 ]),
+                TypeSignature::Exact(vec![DataType::Decimal(38, 10), DataType::Int64]),
+                TypeSignature::Exact(vec![DataType::Float64, DataType::Int64]),
             ],
             fun.volatility(),
         ),

--- a/datafusion/expr/src/function.rs
+++ b/datafusion/expr/src/function.rs
@@ -567,6 +567,8 @@ pub fn signature(fun: &BuiltinScalarFunction) -> Signature {
                 TypeSignature::Exact(vec![DataType::Float64]),
                 TypeSignature::Exact(vec![DataType::Float32]),
                 // NOTE: stub, won't execute
+                TypeSignature::Exact(vec![DataType::Float64, DataType::Int64]),
+                TypeSignature::Exact(vec![DataType::Decimal(38, 10), DataType::Int64]),
                 TypeSignature::Exact(vec![DataType::Decimal(38, 10), DataType::Int32]),
             ],
             fun.volatility(),


### PR DESCRIPTION
Closes https://github.com/cube-js/cube/issues/8905

Add Int64 signatures for log and round function