### PR TITLE
Use GroupsAccumulator exclusively in grouped hash aggregation

### DIFF
--- a/datafusion/src/cube_ext/joinagg.rs
+++ b/datafusion/src/cube_ext/joinagg.rs
@@ -259,7 +259,6 @@ impl ExecutionPlan for CrossJoinAggExec {
                         accumulators = hash_aggregate::group_aggregate_batch(
                             &AggregateMode::Full,
                             &group_expr,
-                            &self.agg_expr,
                             joined,
                             std::mem::take(&mut accumulators),
                             &aggs,

--- a/datafusion/src/physical_plan/distinct_expressions.rs
+++ b/datafusion/src/physical_plan/distinct_expressions.rs
@@ -27,15 +27,14 @@ use arrow::datatypes::{DataType, Field};
 
 use crate::error::{DataFusionError, Result};
 use crate::physical_plan::group_scalar::GroupByScalar;
+use crate::physical_plan::groups_accumulator::GroupsAccumulator;
+use crate::physical_plan::groups_accumulator_flat_adapter::GroupsAccumulatorFlatAdapter;
 use crate::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use crate::scalar::ScalarValue;
 use itertools::Itertools;
 use smallvec::SmallVec;
 use std::collections::hash_map::RandomState;
 use std::collections::HashSet;
-
-use super::groups_accumulator::GroupsAccumulator;
-use super::groups_accumulator_flat_adapter::GroupsAccumulatorFlatAdapter;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 struct DistinctScalarValues(Vec<GroupByScalar>);

--- a/datafusion/src/physical_plan/expressions/average.rs
+++ b/datafusion/src/physical_plan/expressions/average.rs
@@ -118,8 +118,6 @@ impl AggregateExpr for Avg {
         return true;
     }
 
-    /// the groups accumulator used to accumulate values from the expression.  If this returns None,
-    /// create_accumulator must be used.
     fn create_groups_accumulator(
         &self,
     ) -> arrow::error::Result<Option<Box<dyn GroupsAccumulator>>> {

--- a/datafusion/src/physical_plan/expressions/count.rs
+++ b/datafusion/src/physical_plan/expressions/count.rs
@@ -21,6 +21,8 @@ use std::any::Any;
 use std::sync::Arc;
 
 use crate::error::Result;
+use crate::physical_plan::groups_accumulator::GroupsAccumulator;
+use crate::physical_plan::groups_accumulator_flat_adapter::GroupsAccumulatorFlatAdapter;
 use crate::physical_plan::{Accumulator, AggregateExpr, PhysicalExpr};
 use crate::scalar::ScalarValue;
 use arrow::compute;
@@ -88,6 +90,20 @@ impl AggregateExpr for Count {
 
     fn create_accumulator(&self) -> Result<Box<dyn Accumulator>> {
         Ok(Box::new(CountAccumulator::new()))
+    }
+
+    fn uses_groups_accumulator(&self) -> bool {
+        return true;
+    }
+
+    fn create_groups_accumulator(
+        &self,
+    ) -> arrow::error::Result<Option<Box<dyn GroupsAccumulator>>> {
+        Ok(Some(Box::new(GroupsAccumulatorFlatAdapter::<
+            CountAccumulator,
+        >::new(move || {
+            Ok(CountAccumulator::new())
+        }))))
     }
 
     fn name(&self) -> &str {

--- a/datafusion/src/physical_plan/expressions/min_max.rs
+++ b/datafusion/src/physical_plan/expressions/min_max.rs
@@ -105,8 +105,6 @@ impl AggregateExpr for Max {
         return true;
     }
 
-    /// the groups accumulator used to accumulate values from the expression.  If this returns None,
-    /// create_accumulator must be used.
     fn create_groups_accumulator(
         &self,
     ) -> arrow::error::Result<Option<Box<dyn GroupsAccumulator>>> {

--- a/datafusion/src/physical_plan/expressions/sum.rs
+++ b/datafusion/src/physical_plan/expressions/sum.rs
@@ -124,8 +124,6 @@ impl AggregateExpr for Sum {
         return true;
     }
 
-    /// the groups accumulator used to accumulate values from the expression.  If this returns None,
-    /// create_accumulator must be used.
     fn create_groups_accumulator(
         &self,
     ) -> arrow::error::Result<Option<Box<dyn GroupsAccumulator>>> {

--- a/datafusion/src/physical_plan/hash_aggregate.rs
+++ b/datafusion/src/physical_plan/hash_aggregate.rs
@@ -408,16 +408,17 @@ pin_project! {
     }
 }
 
-// TODO: _aggr_expr is currently unused; it's kept for perhaps, debugging usage, but probably just remove it.
 pub(crate) fn group_aggregate_batch(
     mode: &AggregateMode,
     group_expr: &[Arc<dyn PhysicalExpr>],
-    _aggr_expr: &[Arc<dyn AggregateExpr>],
     batch: RecordBatch,
     mut accumulation_state: AccumulationState,
     aggregate_expressions: &[Vec<Arc<dyn PhysicalExpr>>],
     skip_row: impl Fn(&RecordBatch, /*row_index*/ usize) -> bool,
 ) -> Result<AccumulationState> {
+    // Note: There is some parallel array &[Arc<dyn AggregateExpr>] that simply isn't passed to this
+    // function, but which exists and might be useful.
+
     // evaluate the grouping expressions
     let group_values = evaluate(group_expr, &batch)?;
 
@@ -813,7 +814,6 @@ async fn compute_grouped_hash_aggregate(
         accumulators = group_aggregate_batch(
             &mode,
             &group_expr,
-            &aggr_expr,
             batch,
             accumulators,
             &aggregate_expressions,

--- a/datafusion/src/physical_plan/mod.rs
+++ b/datafusion/src/physical_plan/mod.rs
@@ -634,6 +634,37 @@ pub trait Accumulator: Send + Sync + Debug {
     fn evaluate(&self) -> Result<ScalarValue>;
 }
 
+// Used for AggregateExpr implementations that still have uses_groups_accumulator being false.
+impl Accumulator for Box<dyn Accumulator> {
+    fn reset(&mut self) {
+        self.as_mut().reset()
+    }
+
+    fn state(&self) -> Result<SmallVec<[ScalarValue; 2]>> {
+        self.as_ref().state()
+    }
+
+    fn update(&mut self, values: &[ScalarValue]) -> Result<()> {
+        self.as_mut().update(values)
+    }
+
+    fn update_batch(&mut self, values: &[ArrayRef]) -> Result<()> {
+        self.as_mut().update_batch(values)
+    }
+
+    fn merge(&mut self, states: &[ScalarValue]) -> Result<()> {
+        self.as_mut().merge(states)
+    }
+
+    fn merge_batch(&mut self, states: &[ArrayRef]) -> Result<()> {
+        self.as_mut().merge_batch(states)
+    }
+
+    fn evaluate(&self) -> Result<ScalarValue> {
+        self.as_ref().evaluate()
+    }
+}
+
 pub mod aggregates;
 pub mod array_expressions;
 pub mod coalesce_batches;


### PR DESCRIPTION
Makes other AggregateExprs in use GroupsAccumulatorFlatAdapter, and also uses a GroupsAccumulator implementation that has Box<dyn Accumulator> inside as a fallback accumulator if some AggregateExpr implementation does not support that.

This fully removes a batch keys and hash table iteration and brings that performance benefit from Sum and Avg to other aggregation types.
