### PR TITLE
feat: Extend arithmetic negate support for `NULL`s

### DIFF
--- a/datafusion/common/src/scalar.rs
+++ b/datafusion/common/src/scalar.rs
@@ -617,7 +617,9 @@ impl ScalarValue {
             | ScalarValue::Int16(None)
             | ScalarValue::Int32(None)
             | ScalarValue::Int64(None)
+            | ScalarValue::Float64(None)
             | ScalarValue::Float32(None)
+            | ScalarValue::Decimal128(None, _, _)
             | ScalarValue::IntervalYearMonth(None)
             | ScalarValue::IntervalDayTime(None) => self.clone(),
             ScalarValue::Float64(Some(v)) => ScalarValue::Float64(Some(-v)),


### PR DESCRIPTION
This PR extends arithmetic negate support for `Float64` and `Decimal128` scalars when they are `NULL`.