### PR TITLE
fix: Prioritize inner context compound identifier field over outer context

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -19,24 +19,25 @@ name: Dev
 on: [push, pull_request]
 
 jobs:
-  lint:
-    name: Lint C++, Python, R, Rust, Docker
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Arrow
-        uses: actions/checkout@v2
-        with:
-          repository: apache/arrow
-          submodules: true
-          fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.10"
-      - name: Setup Archery
-        run: pip install -e dev/archery[lint]
-      - name: Lint
-        run: archery lint --rat
+  # NOTE(cubesql): `archery lint` is broken, disabling for the time being
+  # lint:
+  #   name: Lint C++, Python, R, Rust, Docker
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout Arrow
+  #       uses: actions/checkout@v2
+  #       with:
+  #         repository: apache/arrow
+  #         submodules: true
+  #         fetch-depth: 0
+  #     - name: Setup Python
+  #       uses: actions/setup-python@v2
+  #       with:
+  #         python-version: "3.10"
+  #     - name: Setup Archery
+  #       run: pip install -e dev/archery[lint]
+  #     - name: Lint
+  #       run: archery lint --rat
 
   rat:
     name: Release Audit Tool (RAT)

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -1991,12 +1991,6 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                                     )));
                                 }
                             }
-                            if let Some(f) = self.context.outer_query_context_schema.iter().find_map(|s| s.field_with_qualified_name(&relation, &name).ok()) {
-                                return Ok(Expr::OuterColumn(f.data_type().clone(), Column {
-                                    relation: Some(relation),
-                                    name,
-                                }))
-                            }
 
                             match schema.field_with_qualified_name(&relation, &name) {
                                 Ok(_) => {
@@ -2022,6 +2016,17 @@ impl<'a, S: ContextProvider> SqlToRel<'a, S> {
                                             expr: Box::new(Expr::Column(field.qualified_column())),
                                             key: Box::new(Expr::Literal(ScalarValue::Utf8(Some(name)))),
                                         })
+                                    } else if let Some(f) = self
+                                        .context
+                                        .outer_query_context_schema
+                                        .iter()
+                                        .find_map(|s| s.field_with_qualified_name(&relation, &name).ok())
+                                    {
+                                        // Access to an outer column from a subquery
+                                        return Ok(Expr::OuterColumn(f.data_type().clone(), Column {
+                                            relation: Some(relation),
+                                            name,
+                                        }))
                                     } else {
                                         // This is a fix for Sort with relation. See filter_idents_test test for more information.
                                         Ok(Expr::Column(Column {
@@ -5376,13 +5381,13 @@ mod tests {
 
     #[test]
     fn subquery_any() {
-        let sql = "select person.id from person where person.id = any(select person.id from person)";
+        let sql = "select person.id from person where person.id = any(select person.id)";
         let expected = "Projection: #person.id\
                         \n  Filter: #person.id = ANY(#__subquery-0.person.id)\
                         \n    Subquery: types=[AnyAll]\
                         \n      TableScan: person projection=None\
                         \n      Projection: ^#person.id, alias=__subquery-0\
-                        \n        TableScan: person projection=None";
+                        \n        EmptyRelation";
         quick_test(sql, expected);
     }
 
@@ -5402,11 +5407,31 @@ mod tests {
     fn subquery_in() {
         let sql =
             "select person.id, person.id in (select person.id from person) from person";
-        let expected = "Projection: #person.id, #person.id IN (#__subquery-0.person.id)\
+        let expected = "Projection: #person.id, #person.id IN (#__subquery-0.id)\
                         \n  Subquery: types=[AnyAll]\
                         \n    TableScan: person projection=None\
-                        \n    Projection: ^#person.id, alias=__subquery-0\
+                        \n    Projection: #person.id, alias=__subquery-0\
                         \n      TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
+    fn subquery_compound_identifier_self_reference() {
+        let sql = "SELECT person.id \
+            FROM person \
+            WHERE person.id IN ( \
+                SELECT person.id \
+                FROM person \
+                WHERE person.id > 10 \
+            )";
+        let expected = "\
+              Projection: #person.id\
+            \n  Filter: #person.id IN (#__subquery-0.id)\
+            \n    Subquery: types=[AnyAll]\
+            \n      TableScan: person projection=None\
+            \n      Projection: #person.id, alias=__subquery-0\
+            \n        Filter: #person.id > Int64(10)\
+            \n          TableScan: person projection=None";
         quick_test(sql, expected);
     }
 

--- a/datafusion/core/tests/sql/parquet.rs
+++ b/datafusion/core/tests/sql/parquet.rs
@@ -48,6 +48,7 @@ async fn parquet_query() {
     assert_batches_eq!(expected, &actual);
 }
 
+#[ignore = "(cubesql) This test relies on parquet compression that we disabled"]
 #[tokio::test]
 async fn parquet_single_nan_schema() {
     let ctx = SessionContext::new();


### PR DESCRIPTION
This PR fixes an issue with queries like this:
```
SELECT table_name
FROM information_schema.tables
WHERE table_name IN (
  SELECT table_name
  FROM information_schema.tables
  WHERE tables.table_name = 'tables'
)
```
In this case, the inner `WHERE` clause would pick outer `table_name` column due to a logic error in compound identifier planning.

Related test is included, plus incorrect tests are adjusted.

Additionally, this PR fixes CI tests by ignoring a test that requires parquet compression, a feature that was recently disabled in this fork, and by disabling a lint with `archery` that does not work.