### PR TITLE
fix: Repartition joins when `target_partitions = 1` when required

### DIFF
--- a/datafusion/core/src/physical_plan/planner.rs
+++ b/datafusion/core/src/physical_plan/planner.rs
@@ -923,7 +923,8 @@ impl DefaultPhysicalPlanner {
                         })
                         .collect::<Result<join_utils::JoinOn>>()?;
 
-                    if session_state.config.target_partitions > 1
+                    if (session_state.config.target_partitions > 1
+                        || physical_right.output_partitioning().partition_count() > 1)
                         && session_state.config.repartition_joins
                     {
                         let (left_expr, right_expr) = join_on


### PR DESCRIPTION
This PR fixes an issue with joins producing incorrect results when `target_partitions` is `1` and the right input of the join happens to have more then one partition (e.g. `Union`).