### PR TITLE
fix: Do not throw error on empty peer based evaluation in window aggregates

### DIFF
--- a/datafusion/core/src/physical_plan/windows/mod.rs
+++ b/datafusion/core/src/physical_plan/windows/mod.rs
@@ -261,6 +261,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn window_function_empty_batch_no_partition_by() -> Result<()> {
+        // An empty input batch flowing into WindowAggExec with an
+        // unpartitioned aggregate window (e.g. COUNT(*) OVER ()) used to fail
+        // with `Internal("Value range cannot be empty")`.
+        use crate::physical_plan::memory::MemoryExec;
+
+        let session_ctx = SessionContext::new();
+        let task_ctx = session_ctx.task_ctx();
+        let schema = Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, true)]));
+
+        let empty_batch = RecordBatch::new_empty(schema.clone());
+        let input = Arc::new(MemoryExec::try_new(
+            &[vec![empty_batch]],
+            schema.clone(),
+            None,
+        )?);
+
+        let window_exec = Arc::new(WindowAggExec::try_new(
+            vec![create_window_expr(
+                &WindowFunction::AggregateFunction(AggregateFunction::Count),
+                "count".to_owned(),
+                &[col("a", &schema)?],
+                &[],
+                &[],
+                Some(WindowFrame::default()),
+                schema.as_ref(),
+            )?],
+            input,
+            schema.clone(),
+        )?);
+
+        let result: Vec<RecordBatch> = collect(window_exec, task_ctx).await?;
+        let total_rows: usize = result.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total_rows, 0);
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_drop_cancel() -> Result<()> {
         let session_ctx = SessionContext::new();
         let task_ctx = session_ctx.task_ctx();

--- a/datafusion/physical-expr/src/window/aggregate.rs
+++ b/datafusion/physical-expr/src/window/aggregate.rs
@@ -20,6 +20,7 @@
 use crate::window::partition_evaluator::find_ranges_in_range;
 use crate::{expressions::PhysicalSortExpr, PhysicalExpr};
 use crate::{window::WindowExpr, AggregateExpr};
+use arrow::array::new_empty_array;
 use arrow::compute::concat;
 use arrow::record_batch::RecordBatch;
 use arrow::{array::ArrayRef, datatypes::Field};
@@ -74,6 +75,11 @@ impl AggregateWindowExpr {
     /// results for peers) and concatenate the results.
     fn peer_based_evaluate(&self, batch: &RecordBatch) -> Result<ArrayRef> {
         let num_rows = batch.num_rows();
+        if num_rows == 0 {
+            // An empty batch with no PARTITION BY would otherwise produce a single
+            // empty peer range, which scan_peers rejects.
+            return Ok(new_empty_array(self.aggregate.field()?.data_type()));
+        }
         let partition_points =
             self.evaluate_partition_points(num_rows, &self.partition_columns(batch)?)?;
         let sort_partition_points =


### PR DESCRIPTION
This PR fixes an issue with peer based evaluation in window aggregates throwing an error when there are no rows. Related test is included.