### PR TITLE
fix: Reject `ORDER BY` over ungrouped columns in aggregate queries

### DIFF
--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -838,6 +838,24 @@ impl LogicalPlanBuilder {
                 .collect::<Result<Vec<_>>>()?
         };
 
+        // Adding missing columns or aggregate expressions may have failed to provide
+        // some of the columns, e.g. when a sort expression references a column
+        // consumed by an Aggregate below and not present in GROUP BY. Such a query
+        // is invalid and must be rejected during planning rather than produce a plan
+        // with unresolvable columns.
+        let mut sort_columns: HashSet<Column> = HashSet::new();
+        exprs
+            .iter()
+            .try_for_each(|expr| utils::expr_to_columns(expr, &mut sort_columns))?;
+        for column in sort_columns {
+            if plan.schema().field_from_column(&column).is_err() {
+                return Err(DataFusionError::Plan(format!(
+                    "column \"{}\" must appear in the GROUP BY clause or be used in an aggregate function",
+                    column.flat_name(),
+                )));
+            }
+        }
+
         let sort_plan = LogicalPlan::Sort(Sort {
             expr: normalize_cols(exprs, &plan)?,
             input: Arc::new(plan.clone()),

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -4870,6 +4870,48 @@ mod tests {
     }
 
     #[test]
+    fn select_order_by_ungrouped_column() {
+        let sql = "SELECT state FROM person GROUP BY state ORDER BY age";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert!(matches!(
+            err,
+            DataFusionError::Plan(msg) if msg.contains(
+                "column \"person.age\" must appear in the GROUP BY clause or be used in an aggregate function"
+            ),
+        ));
+    }
+
+    #[test]
+    fn select_order_by_case_over_ungrouped_column() {
+        // ORDER BY expression references a column consumed by the Aggregate, even
+        // though its CASE conditions match the GROUP BY expression
+        let sql = "SELECT CASE WHEN age > 30 THEN 'old' ELSE 'young' END, COUNT(*) \
+            FROM person \
+            GROUP BY 1 \
+            ORDER BY CASE WHEN age > 30 THEN 1 ELSE 2 END";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert!(matches!(
+            err,
+            DataFusionError::Plan(msg) if msg.contains(
+                "column \"person.age\" must appear in the GROUP BY clause or be used in an aggregate function"
+            ),
+        ));
+    }
+
+    #[test]
+    fn select_order_by_ungrouped_column_no_group_by() {
+        // Implicit aggregation without GROUP BY: ORDER BY cannot reference a raw column
+        let sql = "SELECT COUNT(*) FROM person ORDER BY age";
+        let err = logical_plan(sql).expect_err("query should have failed");
+        assert!(matches!(
+            err,
+            DataFusionError::Plan(msg) if msg.contains(
+                "column \"person.age\" must appear in the GROUP BY clause or be used in an aggregate function"
+            ),
+        ));
+    }
+
+    #[test]
     fn select_group_by() {
         let sql = "SELECT state FROM person GROUP BY state";
         let expected = "Projection: #person.state\


### PR DESCRIPTION
This PR makes `LogicalPlanBuilder::sort` reject queries whose `ORDER BY` references a column that appears neither in `GROUP BY` nor in an aggregate function, matching PostgreSQL's error message. Related tests are included.