### PR TITLE
fix: Resolve `ORDER BY` aggregate expressions when `HAVING` is present

### DIFF
--- a/datafusion/core/src/logical_plan/expr_rewriter.rs
+++ b/datafusion/core/src/logical_plan/expr_rewriter.rs
@@ -18,7 +18,7 @@
 //! Expression rewriter
 
 use super::{Expr, ExprSchemable, Like};
-use crate::logical_plan::plan::{Aggregate, Projection};
+use crate::logical_plan::plan::{Aggregate, Filter, Projection};
 use crate::logical_plan::DFSchema;
 use crate::logical_plan::LogicalPlan;
 use crate::optimizer::utils::from_plan;
@@ -415,12 +415,17 @@ fn rewrite_sort_col_by_aggs(expr: Expr, plan: &LogicalPlan) -> Result<Expr> {
                 let res = resolve_exprs_to_aliases(&expr, &alias_map, input.schema())?;
                 let res = rebase_expr(&res, projection_expr.as_slice(), input)?;
 
-                Ok(if let LogicalPlan::Aggregate(_) = **input {
-                    rewrite_sort_col(res, input)?
-                } else {
-                    res
+                Ok(match **input {
+                    LogicalPlan::Aggregate(_) | LogicalPlan::Filter(_) => {
+                        rewrite_sort_col(res, input)?
+                    }
+                    _ => res,
                 })
             }
+            // A HAVING clause plans a Filter between the final Projection and
+            // the Aggregate; it doesn't change the schema, so look through it
+            // to rewrite sort expressions against the Aggregate below.
+            LogicalPlan::Filter(Filter { input, .. }) => rewrite_sort_col(expr, input),
             _ => Ok(expr),
         }
     }

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -4009,6 +4009,21 @@ mod tests {
     }
 
     #[test]
+    fn select_aggregate_with_group_by_having_and_order_by_aggregate() {
+        let sql = "SELECT first_name, MAX(age)
+                   FROM person
+                   GROUP BY first_name
+                   HAVING MAX(age) < 30
+                   ORDER BY MAX(age) DESC";
+        let expected = "Sort: #MAX(person.age) DESC NULLS FIRST\
+                        \n  Projection: #person.first_name, #MAX(person.age)\
+                        \n    Filter: #MAX(person.age) < Int64(30)\
+                        \n      Aggregate: groupBy=[[#person.first_name]], aggr=[[MAX(#person.age)]]\
+                        \n        TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
+    #[test]
     fn select_aggregate_with_having_with_aggregate_not_in_select() {
         let sql = "SELECT MAX(age)
                    FROM person


### PR DESCRIPTION
This PR fixes `ORDER BY` on an aggregate expression not being resolved to the aggregate output column when the query also has a `HAVING` clause: `rewrite_sort_col_by_aggs` stopped at the `Filter` that `HAVING` plans between the final `Projection` and the `Aggregate`, leaving a raw aggregate call in the `Sort` node. Related test is included.