### PR TITLE
fix: Resolve `ORDER BY` over unprojected columns in aliased projections

### DIFF
--- a/datafusion/core/src/logical_plan/builder.rs
+++ b/datafusion/core/src/logical_plan/builder.rs
@@ -570,15 +570,22 @@ impl LogicalPlanBuilder {
                 for missing_col in missing_cols {
                     let mut normalized_col =
                         normalize_col(Expr::Column(missing_col.clone()), &input)?;
-                    if let Ok(old_field) =
-                        schema.field_with_unqualified_name(&missing_col.name)
-                    {
-                        if old_field.qualifier().is_none() {
-                            let expr_name = normalized_col.name(input_schema)?;
-                            let alias = missing_col.flat_name();
-                            normalized_col = normalized_col.alias(&alias);
-                            alias_map.insert(expr_name, alias);
-                        }
+                    // Alias the added column and remember the mapping whenever the
+                    // added field wouldn't be found by the sort expression that
+                    // requested it: either the name collides with an existing
+                    // unqualified projection column, or the projection is aliased
+                    // and `replace_qualifier` below will replace the added column's
+                    // qualifier with the projection alias, breaking qualified
+                    // references to the original relation.
+                    let collides_with_unqualified = schema
+                        .field_with_unqualified_name(&missing_col.name)
+                        .map(|f| f.qualifier().is_none())
+                        .unwrap_or(false);
+                    if collides_with_unqualified || alias.is_some() {
+                        let expr_name = normalized_col.name(input_schema)?;
+                        let col_alias = missing_col.flat_name();
+                        normalized_col = normalized_col.alias(&col_alias);
+                        alias_map.insert(expr_name, col_alias);
                     }
                     missing_exprs.push(normalized_col);
                 }

--- a/datafusion/core/src/sql/planner.rs
+++ b/datafusion/core/src/sql/planner.rs
@@ -5708,6 +5708,25 @@ mod tests {
         quick_test(sql, expected);
     }
 
+    #[test]
+    fn cte_order_by_unprojected_column_in_aliased_projection() {
+        // The ORDER BY references `cnt`, which is not in the CTE's projection; the
+        // sort machinery must push it into the aliased projection and reference it
+        // through the projection alias
+        let sql =
+            "WITH t1 AS (SELECT state, age, COUNT(*) AS cnt FROM person GROUP BY 1, 2), \
+            t2 AS (SELECT state, age FROM t1 ORDER BY state, cnt DESC) \
+            SELECT * FROM t2";
+        let expected = "Projection: #t2.state, #t2.age\
+            \n  Projection: #t2.state, #t2.age\
+            \n    Sort: #t2.state ASC NULLS LAST, #t2.t1.cnt DESC NULLS FIRST\
+            \n      Projection: #t1.state, #t1.age, #t1.cnt AS t1.cnt, alias=t2\
+            \n        Projection: #person.state, #person.age, #COUNT(UInt8(1)) AS cnt, alias=t1\
+            \n          Aggregate: groupBy=[[#person.state, #person.age]], aggr=[[COUNT(UInt8(1))]]\
+            \n            TableScan: person projection=None";
+        quick_test(sql, expected);
+    }
+
     fn logical_plan(sql: &str) -> Result<LogicalPlan> {
         let planner = SqlToRel::new(&MockContextProvider {});
         let result = DFParser::parse_sql(sql);

--- a/datafusion/core/tests/sql/select.rs
+++ b/datafusion/core/tests/sql/select.rs
@@ -1298,3 +1298,45 @@ async fn count_distinct_integers_aggregated_multiple_partitions() -> Result<()> 
 
     Ok(())
 }
+
+#[tokio::test]
+async fn select_cte_order_by_unprojected_column() -> Result<()> {
+    let ctx = SessionContext::new();
+    let schema = Arc::new(Schema::new(vec![
+        Field::new("c1", DataType::Utf8, false),
+        Field::new("c2", DataType::Int64, false),
+        Field::new("c3", DataType::Int64, false),
+    ]));
+    let data = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(StringArray::from(vec!["a", "a", "b", "b", "c"])),
+            Arc::new(Int64Array::from_slice([5, 10, 7, 3, 42])),
+            Arc::new(Int64Array::from_slice([1, 3, 2, 1, 9])),
+        ],
+    )?;
+    let table = MemTable::try_new(schema, vec![vec![data]])?;
+    ctx.register_table("test", Arc::new(table))?;
+
+    // The CTE's ORDER BY references `total`, which is not in the CTE's
+    // projection; the sort column must be resolved through the aliased
+    // projection
+    let sql = "WITH t1 AS (SELECT c1, c2, SUM(c3) AS total FROM test GROUP BY 1, 2), \
+        t2 AS (SELECT c1, c2 AS v FROM t1 ORDER BY c1, total DESC) \
+        SELECT * FROM t2";
+    let actual = execute_to_batches(&ctx, sql).await;
+    let expected = vec![
+        "+----+----+",
+        "| c1 | v  |",
+        "+----+----+",
+        "| a  | 10 |",
+        "| a  | 5  |",
+        "| b  | 7  |",
+        "| b  | 3  |",
+        "| c  | 42 |",
+        "+----+----+",
+    ];
+    assert_batches_eq!(expected, &actual);
+
+    Ok(())
+}


### PR DESCRIPTION
This PR fixes a planning error where `ORDER BY` referencing a column absent from an aliased projection (e.g. a CTE ordering by a column it doesn't select) failed with `column "..." must appear in the GROUP BY clause or be used in an aggregate function`, because the sort column pushed into the projection got its qualifier replaced by the projection alias while the sort expression kept referencing the original relation. Related test is included.